### PR TITLE
Don't link to notebook.readthedocs.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,10 +133,10 @@
         <h2 class="text-center">Jupyter</h2>
         <ul>
           <li><a href="https://jupyter-client.readthedocs.org">Rich REPL Protocol</a></li>
-          <li><a href="https://notebook.readthedocs.org">Notebook</a>
+          <li><a href="https://jupyter.readthedocs.org">Notebook</a>
             (
              <a href="https://nbformat.readthedocs.org">format</a>,
-             <a href="https://notebook.readthedocs.org">environment</a>,
+             <a href="https://jupyter.readthedocs.org">environment</a>,
              <a href="https://nbconvert.readthedocs.org">conversion</a>
             )
           </li>


### PR DESCRIPTION
That website is just someone's personal notes. I think the desired link is jupyter.rtfd.org.