### PR TITLE
www.rackspace.com -> developer.rackspace.com

### DIFF
--- a/about.html
+++ b/about.html
@@ -106,7 +106,7 @@
             <div class="col6"><a href="https://www.moore.org/"><img src="assets/moore.svg" class="customerLogo"></a></div>
             <div class="col6"><a href="https://www.google.com/"><img src="assets/google-color.svg" class="customerLogo"></a></div>
             <div class="col6"><a href="http://www.microsoft.com/"><img src="assets/microsoft-color.svg" class="customerLogo logo-fix"></a></div>
-            <div class="col6"><a href="http://www.rackspace.com/"><img src="assets/rackspace-color.svg" class="customerLogo logo-fix"></a></div>
+            <div class="col6"><a href="http://developer.rackspace.com/"><img src="assets/rackspace-color.svg" class="customerLogo logo-fix"></a></div>
             <div class="col6"><a href="https://www.fastly.com/"><img src="assets/fastly.svg" class="customerLogo"></a></div>
         </div>
     </div>
@@ -119,8 +119,8 @@
             <p class="supportparagraph">Institutional Partners are companies and universities that support the project by employing Steering Council members. 
             Current Institutional Partners include:</p>
             <div class="col6"><a href="http://continuum.io/"><img src="assets/continuum-color.svg" class="customerLogo" height="60" width="200"></a></div>
-            <div class="col6"><a href="http://http://www.bloomberg.com/"><img src="assets/bloomberg-color.svg" class="customerLogo logo-fix"></a></div>
-            <div class="col6"><a href="http://www.rackspace.com/"><img src="assets/rackspace-color.svg" class="customerLogo"></a></div>
+            <div class="col6"><a href="http://www.bloomberg.com/"><img src="assets/bloomberg-color.svg" class="customerLogo logo-fix"></a></div>
+            <div class="col6"><a href="http://developer.rackspace.com/"><img src="assets/rackspace-color.svg" class="customerLogo"></a></div>
             <div class="col6"><a href="http://www.calpoly.edu/"><img src="assets/poly-color.svg" class="customerLogo"></a></div>
             <div class="col6"><a href="http://www.berkeley.edu/"><img src="assets/berkeley-color.svg" class="customerLogo"></a></div>
         </div>

--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
                     <!--<a href="http://www.nytimes.com"><li class="col"><img src="assets/nyt.svg" class="greydout" alt="New york times" height="50" width="119"></li></a>-->
                     <a href="http://www.oreilly.com"><li class="col"><img src="assets/oreilly.svg" class="greydout" alt="OReilly" height="45" width="244"></li></a>
                     <a href="http://continuum.io"><li class="col"><img src="assets/continuum.svg" class="greydout" alt="Continuum" height="60" width="102"></li></a>
-                    <a href="http://www.rackspace.com"><li class="col"><img src="assets/rackspace.svg" class="greydout" alt="Rackspace" height="60" width="200"></li></a>
+                    <a href="http://developer.rackspace.com"><li class="col"><img src="assets/rackspace.svg" class="greydout" alt="Rackspace" height="60" width="200"></li></a>
                     <a href="https://www.quantopian.com/"><li class="col"><img src="assets/quantopian.svg" class="greydout" alt="Quantopian" height="60" width="118"></li></a>
                     <a href="http://www.netapp.com/us/"><li class="col"><img src="assets/netapp.svg" class="greydout" alt="NetApp" height="60" width="344"></li></a>
                     <a href="https://software-carpentry.org/"><li class="col"><img src="assets/carpentry.svg" class="greydout" alt="Carpentry" height="60" width="131"></li></a>


### PR DESCRIPTION
We (Developer Experience at Rackspace) would love to have links
point to the developer site rather than the main site (as we do
on nbviewer and other places).

While I was at it, I fixed up a URL for Bloomberg too - `http://` was written twice.