### PR TITLE
Oversize logo fix

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -357,6 +357,9 @@ a {
     .hubfeature h2 {
         text-align: center;
     }
+    #hublogo {
+        width: 60%;
+    }
 }
 .architecturedescription p {
     padding-top: 26px;

--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
         <div class="container">
             <div class="hubheader">
                 <div class="hublogo col-md-5">
-                    <img src="assets/hublogo.svg" class="img-responsive" style="margin:0 auto;">
+                    <img src="assets/hublogo.svg" class="img-responsive" style="margin:0 auto;" id="hublogo">
                 </div>
                 <div class="hubdescription col-md-7">
                     <h2>Jupyter for Organizations</h2>


### PR DESCRIPTION
-When the page was viewed at under 992px in width, the jupyterhub logo
was way too big in comparison to the entire site’s elements