### PR TITLE
re-fix the css transitions

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -152,7 +152,7 @@ a {
     text-align: center;
     padding-bottom: 30px;
 }
-@media (max-width: 768px){
+@media (max-width: 767px){
     .jumbotron {
         margin-right: 5%;
     }
@@ -254,7 +254,7 @@ a {
 .buttons a:hover{
     background-color: #DB5106;
 }
-@media(max-width:541px) {
+@media(max-width:509px) {
     #box2 {
         margin-top: 20px;
     }
@@ -703,9 +703,17 @@ a {
 .navbar-bottom li:last-of-type::after {
     content:"";
 }
-@media (max-width: 509) {
+
+@media (min-width: 510px) {
     .follow {
         float: right !important;
+    }
+    .navbar-bottom ul {
+        float: left;
+    }
+}
+@media (max-width: 509px) {
+    .follow {
         display: block;
         margin: 0 auto;
     }


### PR DESCRIPTION
@willingc is that better ?

![screen shot 2015-10-26 at 20 57 22](https://cloud.githubusercontent.com/assets/335567/10749144/56735b8a-7c24-11e5-8348-67489ca1577d.png)

improved less css transition marks:

<img width="816" alt="screen shot 2015-10-26 at 20 57 42" src="https://cloud.githubusercontent.com/assets/335567/10749147/60c5b0f6-7c24-11e5-91df-63fe09f14a93.png">


and #box2 still not overlap:

<img width="573" alt="screen shot 2015-10-26 at 20 58 10" src="https://cloud.githubusercontent.com/assets/335567/10749153/6b9e28fa-7c24-11e5-96c9-779b8092913c.png">
