### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ gem install jekyll
 cd into the root of this directory, 
 
 ```
-jekyll serve --base-url ''
+jekyll serve --baseurl ''
 ```
 
 Open your browser to localhost:4000


### PR DESCRIPTION
`--base-url` is not a valid option, but `--baseurl` is.