### PR TITLE
Mobile Scaling Header Fix

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -156,6 +156,9 @@ a {
     .jumbotron {
         margin-right: 5%;
     }
+    body {
+        padding-top: 50px;
+    }
 }
 
 .notebook-preview p {


### PR DESCRIPTION
When scaling the browser down to mobile, there was a gap between the
header and the navigation bar that made a white gap. Simply adding to
the media tag to change the padding accordingly fixes this.