### PR TITLE
Material Card Fix & Styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -154,47 +154,47 @@ d3.json("graphData.json", function(error, json) {
             <h2>Steering Council</h2>
             <p class="supportparagraph">Our team is primarily led by 10 steering committee members who ultimately make the final decisions.</p>
             <div class="col-md-12">
-            <div class="col-md-4 material material-1">
-               <p class="council-name">Brian Granger<p>
-                <p class="council-info">Cal Poly, San Luis Obispo<br><a href="https://github.com/ellisonbg" target="_blank"><em>@ellisonbg</em></a> on GitHub</p>
+                <div class="col-md-4 material material-1">
+                    <p class="card-header">Brian Granger<p>
+                    <p class="card-info">Cal Poly, San Luis Obispo<br><a href="https://github.com/ellisonbg" target="_blank"><em>@ellisonbg</em></a> on GitHub</p>
+                </div>
+                <div class="col-md-4 material material-1">
+                    <p class="card-header">Damian Avila<p>
+                    <p class="card-info">Continuum Analytics<br><a href="https://github.com/damianavila" target="_blank"><em>@damianavila</em></a> on GitHub</p>
+                </div>
+                <div class="col-md-4 material material-1">
+                    <p class="card-header">Fernando Perez<p>
+                    <p class="card-info">UC Berkeley<br><a href="https://github.com/fperez" target="_blank"><em>@fperez</em></a> on GitHub</p>
+                </div>
+                <div class="col-md-4 material material-1">
+                    <p class="card-header">Jason Grout<p>
+                    <p class="card-info">Bloomberg<br><a href="https://github.com/jasongrout" target="_blank"><em>@jasongrout</em></a> on GitHub</p>
+                </div>
+                <div class="col-md-4 material material-1">
+                    <p class="card-header">Jessica Hamrick<p>
+                    <p class="card-info">UC Berkeley<br><a href="https://github.com/jhamrick" target="_blank"><em>@jhamrick</em></a> on GitHub</p>
+                </div>
+                <div class="col-md-4 material material-1">
+                    <p class="card-header">Jonathan Frederic<p>
+                    <p class="card-info">Cal Poly, San Luis Obispo<br><a href="https://github.com/jdfreder" target="_blank"><em>@jdfreder</em></a> on GitHub</p>
+                </div>
+                <div class="col-md-4 material material-1">
+                    <p class="card-header">Kyle Kelley<p>
+                    <p class="card-info">Rackspace<br><a href="https://github.com/rgbkrk" target="_blank"><em>@rgbkrk</em></a> on GitHub</p>
+                </div>
+                <div class="col-md-4 material material-1">
+                    <p class="card-header">Matthias Bussonnier<p>
+                    <p class="card-info">UC Berkeley<br><a href="https://github.com/carreau" target="_blank"><em>@carreau</em></a> on GitHub</p>
+                </div>
+                <div class="col-md-4 material material-1">
+                    <p class="card-header">Min Ragan-Kelley<p>
+                    <p class="card-info">Simula Research Lab<br><a href="https://github.com/minrk" target="_blank"><em>@minrk</em></a> on GitHub</p>
+                </div>
+                <div class="col-md-4 material material-1">
+                    <p class="card-header">Thomas Kluyver<p>
+                    <p class="card-info">UC Berkeley<br><a href="https://github.com/takluyver" target="_blank"><em>@takluyver</em></a> on GitHub</p>
+                </div>
             </div>
-            <div class="col-md-4 material material-1">
-                <p class="council-name">Damian Avila<p>
-                <p class="council-info">Continuum Analytics<br><a href="https://github.com/damianavila" target="_blank"><em>@damianavila</em></a> on GitHub</p>
-            </div></a>
-            <div class="col-md-4 material material-1">
-                <p class="council-name">Fernando Perez<p>
-                <p class="council-info">UC Berkeley<br><a href="https://github.com/fperez" target="_blank"><em>@fperez</em></a> on GitHub</p>
-            </div>
-            <div class="col-md-4 material material-1">
-                <p class="council-name">Jason Grout<p>
-                <p class="council-info">Bloomberg<br><a href="https://github.com/jasongrout" target="_blank"><em>@jasongrout</em></a> on GitHub</p>
-            </div>
-            <div class="col-md-4 material material-1">
-                <p class="council-name">Jessica Hamrick<p>
-                <p class="council-info">UC Berkeley<br><a href="https://github.com/jhamrick" target="_blank"><em>@jhamrick</em></a> on GitHub</p>
-            </div>
-            <div class="col-md-4 material material-1">
-                <p class="council-name">Jonathan Frederic<p>
-                <p class="council-info">Cal Poly, San Luis Obispo<br><a href="https://github.com/jdfreder" target="_blank"><em>@jdfreder</em></a> on GitHub</p>
-            </div>
-            <div class="col-md-4 material material-1">
-                <p class="council-name">Kyle Kelley<p>
-                <p class="council-info">Rackspace<br><a href="https://github.com/rgbkrk" target="_blank"><em>@rgbkrk</em></a> on GitHub</p>
-            </div>
-            <div class="col-md-4 material material-1">
-                <p class="council-name">Matthias Bussonnier<p>
-                <p class="council-info">UC Berkeley<br><a href="https://github.com/carreau" target="_blank"><em>@carreau</em></a> on GitHub</p>
-            </div>
-            <div class="col-md-4 material material-1">
-                <p class="council-name">Min Ragan-Kelley<p>
-                <p class="council-info">Simula Research Lab<br><a href="https://github.com/minrk" target="_blank"><em>@minrk</em></a> on GitHub</p>
-            </div>
-            <div class="col-md-4 material material-1">
-                <p class="council-name">Thomas Kluyver<p>
-                <p class="council-info">UC Berkeley<br><a href="https://github.com/takluyver" target="_blank"><em>@takluyver</em></a> on GitHub</p>
-            </div>
-        </div>
         </div>
     </div>
 </section>

--- a/community.html
+++ b/community.html
@@ -20,19 +20,24 @@ navbar_gray: true
             <p class="supportparagraph">Please feel free to ask us questions about Project Jupyter!</p>
             <div class="col-md-12">
                 <div class="col-md-4 material material-1">
-                   <p class="community-resource"><a href="http://stackoverflow.com/questions/tagged/jupyter">Jupyter on Stack Overflow</a><p>
+                   <p class="card-header">Jupyter on Stack Overflow<p>
+                    <p class="card-link"><a href="http://stackoverflow.com/questions/tagged/jupyter"><strong>view</strong></a></p>
                 </div>
                 <div class="col-md-4 material material-1">
-                    <p class="community-resource"><a href="https://groups.google.com/forum/#!forum/jupyter">Jupyter Mailing List</a><p>
+                    <p class="card-header">Jupyter Mailing List<p>
+                    <p class="card-link"><a style="padding-top: 27px;" href="https://groups.google.com/forum/#!forum/jupyter"><strong>view</strong></a></p>
                 </div></a>
                 <div class="col-md-4 material material-1">
-                    <p class="community-resource"><a href="https://groups.google.com/forum/#!forum/jupyter-education">Jupyter in Education Mailing List</a><p>
+                    <p class="card-header">Jupyter in Education Mailing List<p>
+                    <p class="card-link"><a href="https://groups.google.com/forum/#!forum/jupyter-education"><strong>view</strong></a></p>
                 </div>
                 <div class="col-md-4 material material-1">
-                    <p class="community-resource"><a href="http://projects.scipy.org/mailman/listinfo/ipython-dev">IPython Mailing List</a><p>
+                    <p class="card-header">IPython Mailing List<p>
+                    <p class="card-link"><a style="padding-top: 27px;" href="http://projects.scipy.org/mailman/listinfo/ipython-dev"><strong>view</strong></a></p>
                 </div>
                 <div class="col-md-4 material material-1">
-                    <p class="community-resource"><a href="https://gitter.im/jupyter/jupyter">Developer Chat Room</a></p>
+                    <p class="card-header">Developer Chat Room</p>
+                    <p class="card-link"><a href="https://gitter.im/jupyter/jupyter"><strong>view</strong></a></p>
                 </div>
             </div>
         </div>

--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -597,16 +597,28 @@ a {
     margin: 0 auto;
     display: block;
 }
-.council-name {
+.card-header {
+    text-align: left;
     float:left;
     font-size: 19px;
     margin-top: 10px;
 }
-.council-info {
+.card-info {
     float:left;
     font-size: 15px;
     text-align: left;
     margin-top: 0px;
+}
+.card-link a {
+    float: left;
+    font-size: 15px;
+    text-align: left;
+    text-transform: uppercase;
+    color: #F27624;
+    line-height: 1;
+}
+.card-link a:hover {
+    text-decoration: none;
 }
 .material {
   background: #fff;
@@ -805,11 +817,6 @@ a {
 .community {
     margin: 0 auto;
     display: block;
-}
-.community-resource {
-    text-align: center;
-    font-size: 19px;
-    margin-top: 10px;
 }
 @media (max-width: 1200px) {
     .navbar-header {


### PR DESCRIPTION
Made a streamlined styling for material design cards that we use on our website condensed into three css classes instead of individualized ones for each page that we used them on. 

They are:
.material-header
.material-info
.material-link

Also cleaned up the Community page with these styling changes to make consistent across pages