### PR TITLE
A few more idiomatic way of writing css.

### DIFF
--- a/community.html
+++ b/community.html
@@ -28,7 +28,7 @@ navbar_gray: true
                         <a href="https://groups.google.com/forum/#!forum/jupyter">VIEW</a>
                     </div>
                 </div>
-                <div id="mailing-list" class="col-sm-6 col-md-12 community-section">
+                <div class="col-sm-6 col-md-12 community-section">
                     <div class="col-md-2">
                         <img src="assets/mail-education.svg" class="com-image">
                     </div>
@@ -52,7 +52,7 @@ navbar_gray: true
                         <a href="https://github.com/jupyter">VIEW</a>
                     </div>
                 </div>
-                <div id="gitter" class="col-sm-6 col-md-12 community-section">
+                <div class="col-sm-6 col-md-12 community-section">
                     <div class="col-md-2">
                         <img src="assets/gitter.svg" class="com-image">
                     </div>
@@ -64,7 +64,7 @@ navbar_gray: true
                         <a href="https://gitter.im/jupyter/jupyter">VIEW</a>
                     </div>
                 </div>
-                <div id="last-block" class="col-sm-offset-3 col-sm-6 col-sm-offset-3 col-md-offset-0 col-md-12 community-section">
+                <div class="col-sm-offset-3 col-sm-6 col-sm-offset-3 col-md-offset-0 col-md-12 community-section">
                     <div class="col-md-2">
                         <img src="assets/stack-overflow.svg" class="com-image">
                     </div>

--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -847,9 +847,10 @@ a {
     background-color: #F27624;
 }
 
-#last-block {
+.community-section:last-child {
     border-bottom: none;
 }
+
 #github-break {
     display: none;
 }
@@ -867,7 +868,7 @@ a {
         padding-top: 0px;
         text-align: center;
     }
-    #gitter, #mailing-list {
+    .community-section:nth-child(even) {
         border-left: 1px solid #E8E8E8;
     }
     .community-section img {


### PR DESCRIPTION
Avoid Ids and use advance css selector.

This allow to redactor the order sections without having to  modify the CSS. 

@cameronoelsen this is a PR against the community-page branch.

Generally you did a much better job at using css classes. I know the need to use `id='...'` can be really strong, but in general it will give you more work in the long run. 

Here you will see that you can use `:nth-child(odd)`, `:nth-child(even)`,`:last-child` to style element only referring to their disposition. That allow someone else to refactor/add/remove/reorder content without having to care about the styling that will always work. 

Side question: Also how come the community-page branch is on the jupyter repo and not your fork ? 