### PR TITLE
Update link for issue reporting to new jupyter/help repo

### DIFF
--- a/community.html
+++ b/community.html
@@ -49,7 +49,7 @@ navbar_gray: true
                         <p>GitHub is our primary place to report issues with Jupyter.</p>
                     </div>
                     <div class="col-md-2 community-button">
-                        <a href="https://github.com/jupyter">VIEW</a>
+                        <a href="https://github.com/jupyter/help">VIEW</a>
                     </div>
                 </div>
                 <div class="col-sm-6 col-md-12 community-section">


### PR DESCRIPTION
Closes #81 

Updates the support link for jupyter github help to direct to the new jupyter/help repo instead of the jupyter organization page in github.

cc/ 
@jhamrick @Carreau for PR review 
@ellisonbg @fperez for notification of content change to the website as per our discussion at the dev meeting