### PR TITLE
Fix front image

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -116,6 +116,10 @@ a {
 .img-container img {
     vertical-align: center;
 }
+#main-logo {
+	height: calc(100% - 20px);
+	margin-top: 10px;
+}
 .header {
     margin: 0 auto;
     display: block;

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ title: Home
                     <span><img class="img-responsive fade-in three" src="assets/circle3.svg" alt="circle of programming language icons"></span>
                 </div>
                 <div class="img-container">
-                    <img class="img-responsive" src="assets/main-logo.svg" alt="jupyter logo">
+                    <img class="img-responsive" id="main-logo" src="assets/main-logo.svg" alt="jupyter logo">
                 </div>
                 <img class="img-responsive" src="assets/white-background.svg" alt="white background">
             </div>


### PR DESCRIPTION
When PR #130 got pushed it messed up the front image because my new svg was a smaller native size than the old one. This new css should at the very least provide a temporary fix. Also, I can't test the site locally for some reason so it would be nice if someone could test the code before merging this PR (I tried it with dev tools and it works).

Here's how it looks right now.

<img width="1319" alt="screen shot 2016-09-25 at 11 47 37 pm" src="https://cloud.githubusercontent.com/assets/12418068/18825906/7c494744-837f-11e6-99da-b14adc463fed.png">
