### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ The **navbar** is in `_data/nav.yml` and look like that:
 head:
     - Home
     - title: Install
-      url: http://jupyter.readthedocs.org/en/latest/install.html
+      url: https://jupyter.readthedocs.io/en/latest/install.html
     - About
     - title: Documentation
-      url: http://jupyter.readthedocs.org/en/latest/install.html
+      url: https://jupyter.readthedocs.io/en/latest/install.html
     - title: Blog
       url: https://blog.jupyter.org
     - Donate

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,10 +1,10 @@
 head:
     - title: Install
-      url: http://jupyter.readthedocs.org/en/latest/install.html
+      url: https://jupyter.readthedocs.io/en/latest/install.html
     - About
     - Resources
     - title: Documentation
-      url: http://jupyter.readthedocs.org/en/latest/index.html
+      url: https://jupyter.readthedocs.io/en/latest/index.html
     - title: NBViewer
       url: https://nbviewer.jupyter.org
     - Widgets

--- a/community.html
+++ b/community.html
@@ -37,7 +37,7 @@ navbar_gray: true
                         <p>The Jupyter documentation is hosted on readthedocs.org.</p>
                     </div>
                     <div class="col-md-2 community-button">
-                        <a href="http://jupyter.readthedocs.org/en/latest/index.html">VIEW</a>
+                        <a href="https://jupyter.readthedocs.io/en/latest/index.html">VIEW</a>
                     </div>
                 </div>
                 <div class="col-sm-6 col-md-12 community-section">

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@ title: Home
                 <h2 style="text-align:center;">Ready to get started?</h2>
                 <div class="buttons">
                     <a href="https://try.jupyter.org/" style="display: inline-block;">Try it in your browser</a>
-                    <a href="http://jupyter.readthedocs.org/en/latest/install.html" style="display: inline-block;" id="box2">Install the Notebook</a>
+                    <a href="https://jupyter.readthedocs.io/en/latest/install.html" style="display: inline-block;" id="box2">Install the Notebook</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.