### PR TITLE
Include installation page in jupyter.org and fix styling

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,6 +1,5 @@
 head:
-    - title: Install
-      url: https://jupyter.readthedocs.io/en/latest/install.html
+    - Install
     - About
     - Resources
     - title: Documentation

--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -67,7 +67,7 @@ animation-delay: 1.1s;
 .navbar-gray {
     background-color: rgb(248,248,248);
 }
-a {
+.navbar a {
     color: black;
 }
 .navbar-fixed-top .navbar-brand {

--- a/install.html
+++ b/install.html
@@ -1,0 +1,46 @@
+---
+layout: default
+title: Install
+navbar_gray: true
+---
+
+<section>
+    <div class="header">
+        <div class="container">
+            <h1>Installing Jupyter</h1>
+        </div>
+    </div>
+</section>
+<section>
+    <div class="container">
+            <h2>Prerequisite: Python</h2>
+            <p>While Jupyter runs code in many programming languages, <strong>Python</strong> is a requirement (Python 3.3 or greater, or Python 2.7) for installing the Jupyter Notebook.</p>
+            <p>We recommend using the <a href="https://www.continuum.io/downloads">Anaconda</a> distribution to install Python and Jupyter. We’ll go through its installation in the next section.</p>
+
+            <h2>Installing Jupyter using Anaconda and conda</h2>
+            <p>For new users, we <strong>highly recommend</strong> <a href="https://www.continuum.io/downloads">installing Anaconda</a>. Anaconda conveniently installs Python, the Jupyter Notebook, and other commonly used packages for scientific computing and data science.</p>
+            <p>We recommend using the Anaconda distribution to install Python and Jupyter. We’ll go through its installation in the next section.</p>
+
+            <ul>
+                <li>Download <a href="https://www.continuum.io/downloads">Anaconda</a>. We recommend downloading Anaconda’s latest Python 3 version (currently Python 3.5).</li>
+                <li>Install the version of Anaconda which you downloaded, following the instructions on the download page.</li>
+                <li>Congratulations, you have installed Jupyter Notebook. To run the notebook:
+                    {% highlight bash %}jupyter notebook{% endhighlight %}
+                </li>
+            </ul>
+            <p>See <a href="https://jupyter.readthedocs.io/en/latest/running.html#running">Running the Notebook</a> for more details.</p>
+
+            <h2>Alternative for experienced Python users: Installing Jupyter with pip</h2>
+            <p>As an existing Python user, you may wish to install Jupyter using Python’s package manager, <a href="https://jupyter.readthedocs.io/en/latest/glossary.html#term-pip">pip</a>, instead of Anaconda.</p>
+            <p>First, ensure that you have the latest pip; older versions may have trouble with some dependencies:</p>
+            {% highlight bash %}pip3 install --upgrade pip{% endhighlight %}
+            <p>Then install the Jupyter Notebook using:</p>
+            {% highlight bash %}pip3 install jupyter{% endhighlight %}
+            <p>(Use pip if using legacy Python 2.)</p>
+            <p>Congratulations. You have installed Jupyter Notebook.</p>
+            <p>See <a href="https://jupyter.readthedocs.io/en/latest/running.html#running">Running the Notebook</a> for more details.</p>
+
+    </div>
+</section>
+
+


### PR DESCRIPTION
- This makes the navbar **Install** link point to a subpage of jupyter.org so that users are not driven out of the website.
- Besides, there is a styling fix in navbar.css which was causing all the `a` tags of the website to be wrongly styled like in the navbar.