### PR TITLE
Remove navbar documentation link

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -3,8 +3,6 @@ head:
       url: https://jupyter.readthedocs.io/en/latest/install.html
     - About
     - Resources
-    - title: Documentation
-      url: https://jupyter.readthedocs.io/en/latest/index.html
     - title: NBViewer
       url: https://nbviewer.jupyter.org
     - Widgets


### PR DESCRIPTION
 - It is misleading that an item of the navbar actually takes people out of the website.
 - The documentation is included in the *Resources* page.

After this and the other PR is merged, only nbviewer and the blog links will take users out.