### PR TITLE
Fix sw carpentry link

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@ title: Home
                     <li class="col"><a href="http://developer.rackspace.com"><img src="assets/rackspace.svg" class="greydout" alt="Rackspace" height="60" width="200"></a></li>
                     <li class="col"><a href="https://www.quantopian.com/"><img src="assets/quantopian.svg" class="greydout" alt="Quantopian" height="60" width="118"></a></li>
                     <li class="col"><a href="http://www.netapp.com/us/"><img src="assets/netapp.svg" class="greydout" alt="NetApp" height="60" width="344"></a></li>
-                    <li class="col"><a href="https://software-carpentry.org"><img src="assets/carpentry.svg" class="greydout" alt="Carpentry" height="60" width="131"></a></li>
+                    <li class="col"><a href="http://software-carpentry.org"><img src="assets/carpentry.svg" class="greydout" alt="Carpentry" height="60" width="131"></a></li>
                     <li class="col"><a href="https://www.janelia.org/"><img src="assets/janelia.svg" class="greydout" alt="Janelia" height="60" width="178"></a></li>
                     <li class="col"><a href="http://codeneuro.org/"><img src="assets/codeneuro.svg" class="greydout" alt="CodeNeuro" height="60" width="296"></a></li>
                     <li class="col"><a href=""><img src="assets/nsite.svg" class="greydout" alt="NSite" height="50" width="94"></a></li>


### PR DESCRIPTION
Update SW Carpentry link so that it no longer fails the HTML Proofer's link check.