### PR TITLE
Lint cleanup

### DIFF
--- a/css/gallery.css
+++ b/css/gallery.css
@@ -9,7 +9,7 @@
     display: inline;
 }
 
-img.img-scaling {
+.img-scaling {
     height: 32px;
     vertical-align: top;
 }

--- a/css/gallery.css
+++ b/css/gallery.css
@@ -2,7 +2,7 @@
     display: flex;
     flex-flow: row;
     justify-content: space-between;
-    margin: 0px 0px 16px 0px;
+    margin: 0 0 16px 0;
 }
 
 .jupyter-widget-header h2 {
@@ -16,8 +16,8 @@ img.img-scaling {
 
 .gallery-title {
     font-size: 32px;
-    line-height: 32px;
     height: 32px;
+    line-height: 32px;
 }
 
 .tabs-left > .nav-tabs {
@@ -32,8 +32,8 @@ img.img-scaling {
 .tab-content > .active,
 .pill-content > .active {
   display: block;
-  margin-top: 26px;
   margin-bottom: 26px;
+  margin-top: 26px;
   min-height: 1100px;
 }
 
@@ -42,23 +42,23 @@ img.img-scaling {
 }
 
 .tabs-left > .nav-tabs > li > a{
-  min-width: 200px;
-  margin-right: 0;
   margin-bottom: 3px;
+  margin-right: 0;
+  min-width: 200px;
 }
 
 .tabs-left > .nav-tabs {
+  border-right: 1px solid #ddd;
   float: left;
   height: 1100px;
   margin-right: 19px;
-  border-right: 1px solid #ddd;
 }
 
 .tabs-left > .nav-tabs > li > a {
-  margin-right: -1px;
   -webkit-border-radius: 4px 0 0 4px;
-     -moz-border-radius: 4px 0 0 4px;
-          border-radius: 4px 0 0 4px;
+  -moz-border-radius: 4px 0 0 4px;
+  border-radius: 4px 0 0 4px;
+  margin-right: -1px;
 }
 
 .tabs-left > .nav-tabs > li > a:hover,

--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -1,7 +1,7 @@
 body {
-    padding-top: 70px;
-    /* Required padding for .navbar-fixed-top. Change if height of navigation changes. */
     font-weight: 400;
+    /* Required padding for .navbar-fixed-top. Change if height of navigation changes. */
+    padding-top: 70px;
 }
 
 /* Navbar and footer (global) styling */
@@ -30,19 +30,18 @@ body {
     color: #E46E2E;
 }
 .navbar-scroll {
-    box-shadow: 1px 1px 1px #999;
+    animation-duration: 2s;
+    animation-name: smooth;
     -moz-box-shadow: 1px 1px 1px #999;
     -webkit-box-shadow: 1px 1px 1px #999;
-    animation-name: smooth;
-    animation-duration: 2s;
+    box-shadow: 1px 1px 1px #999;
 }
 .nav > li > a {
-    padding: 10px 13px;
-    padding-top: 15px;
+    padding: 15px 13px 10px;
 }
 .nav > li > a:hover {
-    color: #E46E2E;
     background-color: transparent;
+    color: #E46E2E;
     -webkit-transition: .2s;
 }
 .nav > li > a:focus {
@@ -55,8 +54,8 @@ body {
     background-color: #F8F8F8;
 }
 .tab:hover {
-    color: #E46E2E;
     background-color: transparent;
+    color: #E46E2E;
 }
 .footer {
     background-color: #979797;
@@ -66,13 +65,13 @@ body {
     padding-top: 10px;
 }
 .footer li{
-    display: inline-block;
     color: white;
+    display: inline-block;
     text-decoration: none;
 }
 .footer a {
-    text-decoration: none;
     color: white;
+    text-decoration: none;
 }
 .footer li::after {
     content:" |";
@@ -96,18 +95,19 @@ body {
 @keyframes fadeIn { from { opacity:0;} to { opacity:1;} }
 /*This entire section related to fading is for the front page with the Jupyter logo*/
 .fade-in {
-    opacity:0;  /* make things invisible upon start */
-    -webkit-animation:fadeIn ease-in 1;  /* call our keyframe named fadeIn, use         animattion ease-in and repeat it only 1 time */
+    -webkit-animation:fadeIn ease-in 1;  /* call our keyframe named fadeIn, use animation ease-in and repeat it only 1 time */
     -moz-animation:fadeIn ease-in 1;
     animation:fadeIn ease-in 1;
-
-    -webkit-animation-fill-mode:forwards;  /* this makes sure that after animation      is done we remain at the last keyframe value (opacity: 1)*/
-    -moz-animation-fill-mode:forwards;
-    animation-fill-mode:forwards;
 
     -webkit-animation-duration:1s;
     -moz-animation-duration:1s;
     animation-duration:1s;
+
+    -webkit-animation-fill-mode:forwards;  /* this makes sure that after animation is done we remain at the last keyframe value (opacity: 1)*/
+    -moz-animation-fill-mode:forwards;
+    animation-fill-mode:forwards;
+
+    opacity:0;  /* make things invisible upon start */
 }
 .fade-in.one {
     -webkit-animation-delay: 0.3s;
@@ -126,23 +126,23 @@ body {
     animation-delay: 1.1s;
 }
 .jumbotron {
-    margin-top:30px;
     background-color: white;
+    margin-top:30px;
     overflow: hidden;
 }
 .jumbotron img {
     margin: 0 auto;
 }
 .jumbotron-text {
-    text-align: center;
     padding-bottom: 32px;
+    text-align: center;
 }
 .img-container {
-    position: absolute;
-    width: 95%;
     height: 100%;
-    text-align: center;
     margin: 0 auto;
+    position: absolute;
+    text-align: center;
+    width: 95%;
 }
 .img-container img {
     vertical-align: center;
@@ -152,22 +152,22 @@ body {
 
 /* Header section of each page */
 .header{
+    background-color: #F8F8F8;
     padding-bottom: 30px;
     text-align: center;
-    background-color: #F8F8F8;
 }
 
 /* Section elements */
 /* Section classes used for particular sections within a page. Sections should differ in background color when used next to each other */
 .section-white {
-  padding: 56px 0;
-  background-color: white;
+    background-color: white;
+    padding: 56px 0;
 }
 .section-grey {
-  padding: 56px 0;
   background-color: #fafafa;
-  border-top: 1px solid #E0E0E0;
   border-bottom: 1px solid #E0E0E0;
+  border-top: 1px solid #E0E0E0;
+  padding: 56px 0;
 }
 /* Used to specifying when a section is at the top or bottom of the page to apply appropriate border */
 .top-section-border {
@@ -187,35 +187,34 @@ body {
 }
 /* Header for each section */
 .section-header {
+    margin: 12px auto 8px;
     text-align: center;
-    margin: 0 auto;
-    margin-top: 12px;
-    margin-bottom: 8px;
 }
 /* Used for descriptions of sections underneath section headers*/
 .support-paragraph {
     font-size: 15px;
     line-height: 1.5;
-    text-align: center;
     margin-bottom: 16px;
+    text-align: center;
 }
 
 /* Orange action button */
 .orange-button {
-    text-align: center;
-    font-size: 16px;
-    display: inline-block;
     background-color: #E46E2E;
-    padding: 13px 26px;
     border-radius: 5.82px;
-    color: white;
-    text-decoration: none;
     box-shadow: 0 3px #863001;
+    color: white;
+    display: inline-block;
+    font-size: 16px;
+    padding: 13px 26px;
+    text-align: center;
+    text-decoration: none;
+
 }
 .orange-button:hover {
     background-color: #F27624;
-    text-decoration: none;
     color: white;
+    text-decoration: none;
 }
 
 /* Jupyter Notebook highlight section on front page */
@@ -223,9 +222,9 @@ body {
     margin-top: 60px;
 }
 .notebook-icon {
-    width: 60px;
     height: auto;
     margin-right: 12px;
+    width: 60px;
 }
 /* Give space between the notebook features (4 features) on front page and the     img + description */
 .notebook-features {
@@ -235,21 +234,21 @@ body {
     padding-top: 16px;
 }
 .nb-desc {
-    line-height: 1.5;
     font-weight: 400;
+    line-height: 1.5;
 }
 
 /* Install prompt on front page */
 .install-prompt {
     background-color: #FAFAFA;
+    border-bottom-color: #BDBDBD;
+    border-left-style: none;
+    border-right-style: none;
     border-style: solid;
     border-top-color: #BDBDBD;
-    border-bottom-color: #BDBDBD;
-    border-right-style: none;
-    border-left-style: none;
     border-width: thin;
-    text-align: center;
     padding: 4px 0 24px 0;
+    text-align: center;
 }
 .prompt-header {
     margin-bottom: 16px;
@@ -262,21 +261,21 @@ body {
     text-align: center;
 }
 .companies li {
-    display: inline-block;
-    vertical-align: center;
-    width: 18%;
-    padding: 2%;
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
+    display: inline-block;
+    padding: 2%;
+    vertical-align: center;
+    width: 18%;
 }
 .companies .col img{
     display: block;
     width: 100%
 }
 .greydout {
-    -webkit-opacity: 0.065;
     -moz-opacity: .065;
+    -webkit-opacity: 0.065;
     opacity: 0.65;
     -webkit-transition: all .5s ease;
     -moz-transition: all .5s ease;
@@ -285,8 +284,8 @@ body {
     transition: all .5s ease;
 }
 .greydout:hover {
-    webkit-opacity: 1;
-    moz-opacity: 1;
+    -webkit-opacity: 1;
+    -moz-opacity: 1;
     opacity: 1;
 }
 
@@ -302,38 +301,38 @@ body {
     margin: 0 auto;
 }
 .hubfeatures {
-    /* Padding that is used to make the hubfeature circles sit on track */
-    padding-top: 48px;
     background: url("../assets/line.svg");
     background-position:  top center;
     background-repeat: no-repeat;
+    /* Padding that is used to make the hubfeature circles sit on track */
+    padding-top: 48px;
 }
 
 /* Architecture section on front page */
 .arcfeature {
     background-color: white;
-    text-align: center;
+    border: 1px solid #CCC;
     border-radius: 5px;
     height: 300px;
-    width: 300px;
     margin: 0 auto;
-    border: 1px solid #CCC;
+    text-align: center;
+    width: 300px;
 }
 .arcfeature .front img, .arcfeature .front2 img, .arcfeature .front3 img {
-    margin-top: 15px;
     margin-bottom: 40px;
+    margin-top: 15px;
 }
 .arcfeature .back p {
     margin-top: 40px;
 }
 /* Specific grey button used on each card in the Architecture section on the front page of the site */
 .arc-button {
-    font-size: 20px;
     background-color: #8D8D8D;
-    box-shadow: 0 3px #595959;
-    padding: 8px 26px;
     border-radius: 5.82px;
+    box-shadow: 0 3px #595959;
     color: white;
+    font-size: 20px;
+    padding: 8px 26px;
     text-decoration: none;
 }
 
@@ -343,9 +342,9 @@ body {
 }
 .card {
     display: block;
+    height: 100%;
     margin: 0 auto;
     text-align:center;
-    height: 100%;
     vertical-align: center;
 }
 /* Used to make cursor turn to link specific cursor when hovering over architecture buttons */
@@ -355,35 +354,33 @@ body {
 
 /* Styling for each card in the architecture section on front page. Each card needs it's own front class to work with the javascript associated with the cards */
 .card .front, .card .front2, .card .front3 {
-    width: 275px;
-    height: 275px;
-    transition: transform 0.3s linear 0s;
-    -webkit-transition: -webkit-transform 0.3s linear 0s;
-
     -webkit-backface-visibility: hidden;
-       -moz-backface-visibility: hidden;
-         -o-backface-visibility: hidden;
-            backface-visibility: hidden;
+    -moz-backface-visibility: hidden;
+    -o-backface-visibility: hidden;
+    backface-visibility: hidden;
+    height: 275px;
     position: absolute;
     text-align: center;
+    -webkit-transition: -webkit-transform 0.3s linear 0s;
+    transition: transform 0.3s linear 0s;
+    width: 275px;
 }
 .flipped {
-    transform: rotateY(180deg);
     -webkit-transform: rotateY(180deg);
+    transform: rotateY(180deg);
 }
 .content-back p{
-    margin-top: 10px;
     margin-bottom: 16px;
+    margin-top: 10px;
 }
 .card .back{
-    transform: rotateY(180deg);
-    -webkit-transform: rotateY(180deg);
-
     text-align: center;
+    -webkit-transform: rotateY(180deg);
+    transform: rotateY(180deg);
 }
 .arcfeature a {
-    text-decoration: none;
     color: white;
+    text-decoration: none;
 }
 .arcfeature img {
     margin: 0 auto;
@@ -403,24 +400,24 @@ body {
 
 /* .Card-header, .card-info, .card-link, and .material are used for cards within the steering council section of the page. */
 .card-header {
-    text-align: left;
     float:left;
     font-size: 19px;
     margin-top: 10px;
+    text-align: left;
 }
 .card-info {
     float:left;
     font-size: 15px;
-    text-align: left;
     margin-top: 0;
+    text-align: left;
 }
 .card-link a {
+    color: #F27624;
     float: left;
     font-size: 15px;
+    line-height: 1;
     text-align: left;
     text-transform: uppercase;
-    color: #F27624;
-    line-height: 1;
 }
 .card-link a:hover {
     text-decoration: none;
@@ -428,31 +425,31 @@ body {
 .material {
     background: #fff;
     border-radius: 2px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
     display: inline-block;
     height: 130px;
     margin: 1rem;
     position: relative;
-    width: 200px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
     transition: all 0.2s ease-in-out;
+    width: 200px;
 }
 /* Styling for the Sponsor logos on About page*/
 .sponsor {
     margin: 16px 0;
 }
 .sponsor-logo {
-    width: 75%;
     height: auto;
+    width: 75%;
 }
 
 /* Used to style the clickable tabs within the governance section */
 .clickable{
-    display: inline-block;
-    text-decoration: none;
-    font-size: 20px;
-    margin-left: 20px;
-    margin-bottom: 10px;
     cursor: default;
+    display: inline-block;
+    font-size: 20px;
+    margin-bottom: 10px;
+    margin-left: 20px;
+    text-decoration: none;
 }
 .clickable:hover {
     color: #E46E2E
@@ -466,34 +463,34 @@ body {
 /* Used to style the description of a particular tab within the governance section */
 .governance-desc {
     border-color: black;
-    border-width: thin;
-    border-style: solid;
-    border-radius: 5px;
     border-color: #979797;
+    border-radius: 5px;
+    border-style: solid;
+    border-width: thin;
+    min-height: 100px;
     padding: 30px;
     transition: all 1s;
-    min-height: 100px;
 }
 
 /* Donate Page */
 .donate-box {
     background-color: white;
-    height: 500px;
-    border-radius: 8px;
     border-color: #979797;
+    border-radius: 8px;
     border-style: solid;
     border-width: 1px;
-    padding: 32px;
-    margin-top: 5%;
+    height: 500px;
     height: 20%;
+    margin-top: 5%;
+    padding: 32px;
 }
 
 /*Community Resources Page */
 
 /* Resource section is used to create a new resource on the community resources page. */
 .resource-section {
-    padding: 16px;
     border-bottom: 1px solid #E8E8E8;
+    padding: 16px;
     vertical-align: middle;
 }
 /* Used to specify that the last resource should not have a border underneath it's content */
@@ -505,25 +502,25 @@ body {
     vertical-align: middle;
 }
 .resource-logo {
-    height: 80px;
     display: block;
+    height: 80px;
     margin: 0 auto;
 } 
 .resource-name {
      margin-top: 6px;
 }
 .resource-button {
-    text-align: center;
     margin-top: 32px;
+    text-align: center;
 }
 .resource-button a {
     background-color: #E46E2E;
-    padding: 13px 60px;
     border-radius: 5.82px;
-    text-decoration: none;
     box-shadow: 0 3px #863001;
     color: white;
     letter-spacing: 1px;
+    padding: 13px 60px;
+    text-decoration: none;
     -webkit-transition: .2s;
 }
 .resource-button a:hover {
@@ -534,7 +531,7 @@ body {
 /* Large devices (large desktops, 1200px and up) */
 @media (min-width: 1200px) {
   .section-white, .section-grey {
-    padding: 5% 0%;
+    padding: 5% 0;
   }
 }
 @media (max-width: 1200px) {
@@ -548,8 +545,8 @@ body {
         padding-top: 4px;
     }
     .notebook-preview p {
-        line-height: 25pt;
         font-size: 15pt;
+        line-height: 25pt;
     }
     .companies li{
         width:23%;
@@ -559,55 +556,55 @@ body {
 @media (min-width: 992px) {
     p {
         font-size: 16px;
-        line-height: 1.375;
         font-weight: 400;
+        line-height: 1.375;
     }
     h4 {
         font-size: 18px;
-        line-height: 1.22;
         font-weight: 500;
+        line-height: 1.22;
     }
     h3 {
         font-size: 28px;
-        line-height: 1.25;
         font-weight: 500;
+        line-height: 1.25;
     }
     h2 {
         font-size: 36px;
-        line-height: 1.25;
         font-weight: 500;
+        line-height: 1.25;
     }
     h1 {
         font-size: 48px;
-        line-height: 1.05em;
         font-weight: 500;
+        line-height: 1.05em;
     }
 }
 @media (max-width: 992px) {
     p {
         font-size: 16px;
-        line-height: 1.25em;
         font-weight: 400;
+        line-height: 1.25em;
     }
     h4 {
         font-size: 18px;
-        line-height: 1.11em;
         font-weight: 500;
+        line-height: 1.11em;
     }
     h3 {
         font-size: 22px;
-        line-height: 1.136em;
         font-weight: 500;
+        line-height: 1.136em;
     }
     h2 {
         font-size: 26px;
-        line-height: 1.153em;
         font-weight: 500;
+        line-height: 1.153em;
     }
     h1 {
         font-size: 32px;
-        line-height: 1.25em;
         font-weight: 500;
+        line-height: 1.25em;
     }
     .nb-highlight-text {
         text-align: center;
@@ -661,17 +658,15 @@ body {
         margin-top: 10%;
     }
     .resource-section {
-        padding: 0;
-        padding-top: 10px;
-        padding-bottom: 30px;
         height: 400px;
+        padding: 10px 0 30px;
     }
     .resource-section:nth-child(even) {
         border-left: 1px solid #E8E8E8;
     }
     .resource-section img {
-        padding-bottom: 0;
         margin-top: 15px;
+        padding-bottom: 0;
     }
     .resource-content {
         padding-top: 48px;
@@ -704,28 +699,28 @@ body {
 @media (max-width: 768px) {
     p {
         font-size: 16px;
-        line-height: 1.25em;
         font-weight: 400;
+        line-height: 1.25em;
     }
     h4 {
         font-size: 18px;
-        line-height: 1.11em;
         font-weight: 500;
+        line-height: 1.11em;
     }
     h3 {
         font-size: 22px;
-        line-height: 1.136em;
         font-weight: 500;
+        line-height: 1.136em;
     }
     h2 {
         font-size: 26px;
-        line-height: 1.153em;
         font-weight: 500;
+        line-height: 1.153em;
     }
     h1 {
         font-size: 32px;
-        line-height: 1.25em;
         font-weight: 500;
+        line-height: 1.25em;
     }
     .navbar-header {
         margin-bottom: 0;
@@ -757,16 +752,16 @@ body {
         margin-top: 20px;
     }
     .items {
-        padding:10px;
         min-height:0;
+        padding:10px;
     }
     .follow {
         display: block;
         margin: 0 auto;
     }
     .footer {
-        text-align: center;
         padding-bottom: 15px;
+        text-align: center;
     }
     .footer ul {
         float: left;

--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -81,8 +81,8 @@ body {
     content:"";
 }
 .footer-text {
-    margin-left: 0px;
-    padding-left: 0px;
+    margin-left: 0;
+    padding-left: 0;
 }
 
 /*Main logo animation on the front page of the Jupyter website */
@@ -160,11 +160,11 @@ body {
 /* Section elements */
 /* Section classes used for particular sections within a page. Sections should differ in background color when used next to each other */
 .section-white {
-  padding: 56px 0px;
+  padding: 56px 0;
   background-color: white;
 }
 .section-grey {
-  padding: 56px 0px;
+  padding: 56px 0;
   background-color: #fafafa;
   border-top: 1px solid #E0E0E0;
   border-bottom: 1px solid #E0E0E0;
@@ -210,7 +210,7 @@ body {
     border-radius: 5.82px;
     color: white;
     text-decoration: none;
-    box-shadow: 0px 3px #863001;
+    box-shadow: 0 3px #863001;
 }
 .orange-button:hover {
     background-color: #F27624;
@@ -249,7 +249,7 @@ body {
     border-left-style: none;
     border-width: thin;
     text-align: center;
-    padding: 4px 0px 24px 0px;
+    padding: 4px 0 24px 0;
 }
 .prompt-header {
     margin-bottom: 16px;
@@ -330,7 +330,7 @@ body {
 .arc-button {
     font-size: 20px;
     background-color: #8D8D8D;
-    box-shadow: 0px 3px #595959;
+    box-shadow: 0 3px #595959;
     padding: 8px 26px;
     border-radius: 5.82px;
     color: white;
@@ -339,7 +339,7 @@ body {
 
 #arcfeature1 a:hover, #protocol a:hover, #kernel a:hover {
     background-color: #DB5106;
-    box-shadow: 0px 3px #863001;
+    box-shadow: 0 3px #863001;
 }
 .card {
     display: block;
@@ -412,7 +412,7 @@ body {
     float:left;
     font-size: 15px;
     text-align: left;
-    margin-top: 0px;
+    margin-top: 0;
 }
 .card-link a {
     float: left;
@@ -438,7 +438,7 @@ body {
 }
 /* Styling for the Sponsor logos on About page*/
 .sponsor {
-    margin: 16px 0px;
+    margin: 16px 0;
 }
 .sponsor-logo {
     width: 75%;
@@ -521,7 +521,7 @@ body {
     padding: 13px 60px;
     border-radius: 5.82px;
     text-decoration: none;
-    box-shadow: 0px 3px #863001;
+    box-shadow: 0 3px #863001;
     color: white;
     letter-spacing: 1px;
     -webkit-transition: .2s;
@@ -542,7 +542,7 @@ body {
         margin-top: 32px;
     }
     .notebook-features .language-set h2{
-        padding-top: 0px;
+        padding-top: 0;
     }
     .notebook-features #feature {
         padding-top: 4px;
@@ -613,7 +613,7 @@ body {
         text-align: center;
     }
     .notebook-features {
-        margin-top: 0px;
+        margin-top: 0;
     }
     .language-set #feature {
         display: block;
@@ -661,7 +661,7 @@ body {
         margin-top: 10%;
     }
     .resource-section {
-        padding: 0px;
+        padding: 0;
         padding-top: 10px;
         padding-bottom: 30px;
         height: 400px;
@@ -670,14 +670,14 @@ body {
         border-left: 1px solid #E8E8E8;
     }
     .resource-section img {
-        padding-bottom: 0px;
+        padding-bottom: 0;
         margin-top: 15px;
     }
     .resource-content {
         padding-top: 48px;
     }
     .resource-text {
-        padding-top: 0px;
+        padding-top: 0;
         text-align: center;
     }
     .nav>li>a {
@@ -758,7 +758,7 @@ body {
     }
     .items {
         padding:10px;
-        min-height:0px;
+        min-height:0;
     }
     .follow {
         display: block;

--- a/css/syntax.css
+++ b/css/syntax.css
@@ -1,6 +1,6 @@
 .highlight .err {
-    color: #a61717;
     background-color: #e3d2d2;
+    color: #a61717;
 }
 
 .highlight .k {
@@ -28,18 +28,18 @@
 
 .highlight .cs {
     color: #999999;
-    font-weight: bold;
     font-style: italic;
+    font-weight: bold;
 }
 
 .highlight .gd {
-    color: #000000;
     background-color: #ffdddd;
+    color: #000000;
 }
 
 .highlight .gd .x {
-    color: #000000;
     background-color: #ffaaaa;
+    color: #000000;
 }
 
 .highlight .ge {
@@ -55,13 +55,13 @@
 }
 
 .highlight .gi {
-    color: #000000;
     background-color: #ddffdd;
+    color: #000000;
 }
 
 .highlight .gi .x {
-    color: #000000;
     background-color: #aaffaa;
+    color: #000000;
 }
 
 .highlight .go {
@@ -250,6 +250,6 @@
 }
 
 .highlight .gc {
-    color: #999;
     background-color: #EAF2F5;
+    color: #999;
 }


### PR DESCRIPTION
Edit CSS files to reduce the warnings emitted by CSSLint

`gallery.css` 11 -> 4 warnings

`logo-nav.css` 133-> 42 warnings

`syntax.css` 7 -> 0 warnings

There are still warnings related to id selectors, headings, star-prefix for old ie browsers, etc. Also, alphabetizing the properties uncovered a few places where the same property was being defined twice in the same code block.