### PR TITLE
Took out right border on install prompt

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -243,10 +243,10 @@ body {
     background-color: #FAFAFA;
     border-bottom-color: #BDBDBD;
     border-left-style: none;
-    border-right-style: none;
     border-style: solid;
     border-top-color: #BDBDBD;
     border-width: thin;
+    border-right: 0px;
     padding: 4px 0 24px 0;
     text-align: center;
 }


### PR DESCRIPTION
There was an unnecessary border on the righthand side of the install prompt on the main page of the website:

#### Before
![screen shot 2016-11-08 at 4 59 38 pm](https://cloud.githubusercontent.com/assets/6437976/20123546/c21f7ad2-a5d4-11e6-849e-3a0f6a78d086.png)

#### After
![screen shot 2016-11-08 at 5 00 16 pm](https://cloud.githubusercontent.com/assets/6437976/20123576/d7e984a2-a5d4-11e6-86ec-04d6016ace16.png)
