### PR TITLE
External links open in a new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,8 +40,8 @@ title: Home
                 <div class="col-xs-12">
                     <h3 class="prompt-header">Ready to get started?</h3>
                     <div>
-                        <a class="orange-button" href="https://try.jupyter.org/">Try it in your browser</a>
-                        <a class="orange-button install-button" href="https://jupyter.readthedocs.io/en/latest/install.html">Install the Notebook</a>
+                        <a class="orange-button" href="https://try.jupyter.org/" target="_blank">Try it in your browser</a>
+                        <a class="orange-button install-button" href="https://jupyter.readthedocs.io/en/latest/install.html" target="_blank">Install the Notebook</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Pickup up some of the work from #140 .

From user testing the website, users were confused when they couldn't get back to the main website after navigating to documentation or trying the notebook in the browser.

It would be more clear to users if those links opened in a new tab.