### PR TITLE
Adding pip install instructions

### DIFF
--- a/widgets.html
+++ b/widgets.html
@@ -87,6 +87,9 @@ navbar_gray: true
           <h3>Installation</h3>
           With conda:
           {% highlight bash %}conda install -c conda-forge ipyleaflet{% endhighlight %}
+          With pip:
+          {% highlight bash %}pip install ipyleaflet
+          jupyter nbextension enable --py --sys-prefix ipyleaflet{% endhighlight %}
         </div>
         <div class="tab-pane" id="bqplot">
           <div class="jupyter-widget-header">
@@ -113,6 +116,9 @@ navbar_gray: true
           <h3>Installation</h3>
           With conda:
           {% highlight bash %}conda install -c conda-forge bqplot{% endhighlight %}
+          With pip:
+          {% highlight bash %}pip install bqplot
+          jupyter nbextension enable --py --sys-prefix bqplot{% endhighlight %}
         </div>
         <div class="tab-pane" id="pythreejs">
           <div class="jupyter-widget-header">
@@ -138,6 +144,9 @@ navbar_gray: true
           <h3>Installation</h3>
           With conda:
           {% highlight bash %}conda install -c conda-forge pythreejs{% endhighlight %}
+          With pip:
+          {% highlight bash %}pip install pythreejs
+          jupyter nbextension enable --py --sys-prefix pythreejs{% endhighlight %}
         </div>
         <div class="tab-pane" id="cookiecutter">
           <div class="jupyter-widget-header">


### PR DESCRIPTION
Since that key bit of `jupyter nbextension enable --py --sys-prefix <widget name>` is automatically done by condo, but not pip.

This just bit me as a new user.