### PR TITLE
Fixed Bootstrap default css for .orange-button :active and :focus states

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -222,6 +222,11 @@ body {
     color: white;
     text-decoration: none;
 }
+.orange-button:active, .orange-button:focus {
+    background-color: #DC601C;
+    color: white;
+    text-decoration: none;
+}
 
 /* Jupyter Notebook highlight section on front page */
 .nb-highlight-text {


### PR DESCRIPTION
Hello all!

I was looking at the Jupyter website for sentimental reasons (_which looks amazing by the way, I love the splash hero screen for JupyterCon_ 😍), but I noticed that the `:active` and `:focus` states of the `.orange-button` class were defaulting to the Bootstrap boilerplate, which was didn't show well in my opinion:

<img width="720" alt="orangebutton-before" src="https://cloud.githubusercontent.com/assets/9501647/22667808/31db79fe-ec73-11e6-94c5-f5b191abb1b6.png">

I made a small tweak in the logo-nav.css (where the `.orange-button` css is located) to eliminate the text decoration and color change of the font, and I made the background-color of the button just a shade lower than the original `#E46E2E` orange color of the button (which can of course be changed by a different Jupyter designer if necessary). The result `:active` and `:focus` states appear as:

<img width="720" alt="orangebutton-after" src="https://cloud.githubusercontent.com/assets/9501647/22667814/380e8e92-ec73-11e6-9b86-9b5670f03df0.png">

Everything should be set to merge. Make changes as you wish!
@cameronoelsen @ellisonbg 
