### PR TITLE
Fix HTML Validation errors

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,9 +15,9 @@
                            {% endfor %}
                       {% endif %}
                     {% endfor %}
-                    <p>Copyright © {{site.time | date: '%Y' }}  Project Jupyter - Last updated {{site.time | date: "%a, %b %d, %Y" }}</p>
                     <!--{{ site.time}}-->
                 </ul>
+                <p>Copyright © {{site.time | date: '%Y' }}  Project Jupyter - Last updated {{site.time | date: "%a, %b %d, %Y" }}</p>
             </div>
             <div class="follow">
                 <a class="github-button" href="https://github.com/jupyter" aria-label="Follow @jupyter on GitHub">Follow @jupyter</a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
 
     <title>{{ site.title }} {% if page.title %}| {{ page.title }}{% endif %}</title>
     <meta property="og:title" content="Project Jupyter" />
-    <meta name="description" property="og:description" content="{{ site.description }}">
+    <meta property="og:description" content="{{ site.description }}">
     <meta property="og:url" content="http://www.jupyter.org" />
     <meta property="og:image" content="http://jupyter.org/assets/homepage.png" />
     <!-- Bootstrap Core CSS -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,8 +8,7 @@
 
     <title>{{ site.title }} {% if page.title %}| {{ page.title }}{% endif %}</title>
     <meta property="og:title" content="Project Jupyter" />
-    <meta property="og:description" content="{{ site.description }}" />
-    <meta name="description" content="{{ site.description }}">
+    <meta name="description" property="og:description" content="{{ site.description }}">
     <meta property="og:url" content="http://www.jupyter.org" />
     <meta property="og:image" content="http://jupyter.org/assets/homepage.png" />
     <!-- Bootstrap Core CSS -->
@@ -45,4 +44,3 @@
     </script>
     <script>console.log('Welcome to Project Jupyter! Explore the various tools available and their corresponding documentation. If you are interested in contributing to the platform, please visit the community resources section at http://jupyter.org/community.html.')</script>
 </head>
-

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ title: Home
         <div class="container">
             <div class="row">
                 <div class="col-md-12">
-                    <img src="/assets/jupytercon-logo.svg" id="jupytercon-logo" class="img-responsive"/>
+                    <img src="/assets/jupytercon-logo.svg" alt="Jupytercon announcement logo" id="jupytercon-logo" class="img-responsive"/>
                     <h2 class="jupytercon-header">Announcing JupyterCon</h2>
                     <h3 class="jupytercon-subheader">August 22 - 25, 2017</h3>
                     <h3 class="jupytercon-subheader">New York, NY</h3>


### PR DESCRIPTION
Fixes the following errors:
- document cannot contain more than 1 `meta` attribute with `name` set to `description`
- an `img` element must have an `alt` attribute
- `p` element not allowed as child of `ul`

This code is also on: https://charnpreetsingh.github.io for easy checking.