### PR TITLE
Adding BSD 3 license hyperlink

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -23,7 +23,7 @@ navbar_gray: true
                 <img src="assets/donations-icon2.svg" class="section-icon" alt="donations icon">
                 <h3 class="section-header">Donations</h3>
                 <p id="support-paragraph">Jupyter will always be 100% open source software, free for all to use and
-                released under the liberal terms of the modified BSD license. If you have found Jupyter to be useful in your work, research or company, please consider making a donation to the project commensurate with your resources. Any amount helps!
+                released under the liberal terms of the <a href="https://opensource.org/licenses/BSD-3-Clause">modified BSD license</a>. If you have found Jupyter to be useful in your work, research or company, please consider making a donation to the project commensurate with your resources. Any amount helps!
                 All donations will be used strictly to fund the development of Project Jupyter's open source software, documentation
                 and community.
                 </p>


### PR DESCRIPTION
I think a link to the BSD license page will help users navigate to the page with ease