### PR TITLE
make it clear that Jupyter is open source

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,7 +32,7 @@ navbar_gray: true
             <div class="row">
                 <div class="col-xs-12">
                     <h2>About Project Jupyter</h2>
-                    <p>Project Jupyter was born out of the IPython Project in 2014 as it evolved to support interactive data science and scientific computing across all programming languages.</p>
+                    <p>Project Jupyter is an open source project was born out of the <a href="https://ipython.org">IPython Project</a> in 2014 as it evolved to support interactive data science and scientific computing across all programming languages. Jupyter will always be 100% open source software, free for all to use and released under the liberal terms of the <a href="https://opensource.org/licenses/BSD-3-Clause">modified BSD license</a></p>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ title: Home
                     </div>
                     <div class="col-md-6 nb-highlight-text">
                         <h3><img src="assets/nbicon.svg" class="notebook-icon" alt="notebook icon">The Jupyter Notebook</h3>
-                        <h4 class="nb-desc">The Jupyter Notebook is a web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text. Uses include: data cleaning and transformation, numerical simulation, statistical modeling, machine learning and much more.</h4>
+                        <h4 class="nb-desc">The Jupyter Notebook is an open-source web application that allows you to create and share documents that contain live code, equations, visualizations and explanatory text. Uses include: data cleaning and transformation, numerical simulation, statistical modeling, machine learning and much more.</h4>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
If someone just learned of Jupyter and visits the front page, it's not at all clear that we're not a company selling a product. I also added a link to IPython - since ipython.org links back here, and added the same blurb that only appears on the donate page at present about how Jupyter is and always will be BSD licensed.