### PR TITLE
Fixed overflow of navigation items on screen sizes between 768 and 992px

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -742,9 +742,15 @@ body {
         padding-top: 0;
         text-align: center;
     }
+    .navbar-logo {
+      height: 36px;
+      margin-top: 4px;
+    }
     .nav>li>a {
         font-size: 13px;
-        letter-spacing: 1px;
+        letter-spacing: .8px;
+        padding-left: 8px;
+        padding-right: 8px;
     }
 }
 /* Small devices (tablets, 768px and up) */
@@ -788,6 +794,11 @@ body {
         font-size: 32px;
         font-weight: 500;
         line-height: 1.25em;
+    }
+    .nav>li>a {
+        letter-spacing: 1px;
+        padding-left: 16px;
+        padding-right: 16px;
     }
     .navbar-header {
         margin-bottom: 0;


### PR DESCRIPTION
We are still in the process of generating the top level navigation dropdown items for the website. For the time being, I made it so that the navigation bar doesn't overflow anymore into the second level below the icon on small devices (this can be seen in the screenshots below):

### Before fix
![screen shot 2017-03-17 at 3 21 21 pm](https://cloud.githubusercontent.com/assets/6437976/24065050/80474cbe-0b25-11e7-84bb-9ba1a51529a8.png)

### After fix
![screen shot 2017-03-17 at 3 21 24 pm](https://cloud.githubusercontent.com/assets/6437976/24065052/83a7a96c-0b25-11e7-8b37-15d0d3010373.png)


This navbar also corresponds with the new jupyter documentation theme for jupyter products that will be shipping in the coming weeks.