### PR TITLE
Update Links in Documentation Page

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -64,7 +64,7 @@ navbar_white: true
                       <li><a href="https://jupyterlab-tutorial.readthedocs.io/en/latest/extensions_dev.html">Extensions Developer Guide</a></li>
                       <li><a href="http://jupyterlab-tutorial.readthedocs.io/en/latest/documents.html">Documents</a></li>
                       <li><a href="https://jupyterlab-tutorial.readthedocs.io/en/latest/notebook.html">Notebook</a></li>
-                      <li><a href="https://jupyterlab-tutorial.readthedocs.io/en/latest/patterns.html">Design Pattens</a></li>
+                      <li><a href="https://jupyterlab-tutorial.readthedocs.io/en/latest/patterns.html">Design Patterns</a></li>
                     </ul>
                   </div>
                   <div class="dropdown col-lg-4 col-md-6 col-sm-6">

--- a/documentation.html
+++ b/documentation.html
@@ -59,12 +59,12 @@ navbar_white: true
                       <h4 class="docs-project-tile-head docs-project-one-line">JupyterLab</h4>
                     </div>
                     <ul class="jupyterlab-dropdown-menu docs-dropdown-menu dropdown-menu" aria-labelledby="jupyterlab-block">
-                      <li><a href="http://jupyterlab.readthedocs.io/en/latest/">JupyterLab</a></li>
-                      <li><a href="http://jupyterlab.readthedocs.io/en/latest/plugins.html">Plugins</a></li>
-                      <li><a href="http://jupyterlab.readthedocs.io/en/latest/labextensions.html">Extensions</a></li>
-                      <li><a href="http://jupyterlab.readthedocs.io/en/latest/documents.html">Documents</a></li>
-                      <li><a href="http://jupyterlab.readthedocs.io/en/latest/notebook.html">Notebook</a></li>
-                      <li><a href="http://jupyterlab.readthedocs.io/en/latest/patterns.html">Design Pattens</a></li>
+                      <li><a href="https://jupyterlab-tutorial.readthedocs.io/en/latest/">JupyterLab</a></li>
+                      <li><a href="https://jupyterlab-tutorial.readthedocs.io/en/latest/extensions_user.html">Extensions User Guide</a></li>
+                      <li><a href="https://jupyterlab-tutorial.readthedocs.io/en/latest/extensions_dev.html">Extensions Developer Guide</a></li>
+                      <li><a href="http://jupyterlab-tutorial.readthedocs.io/en/latest/documents.html">Documents</a></li>
+                      <li><a href="https://jupyterlab-tutorial.readthedocs.io/en/latest/notebook.html">Notebook</a></li>
+                      <li><a href="https://jupyterlab-tutorial.readthedocs.io/en/latest/patterns.html">Design Pattens</a></li>
                     </ul>
                   </div>
                   <div class="dropdown col-lg-4 col-md-6 col-sm-6">
@@ -85,7 +85,7 @@ navbar_white: true
                       <li><a href="https://ipython.readthedocs.io/en/stable/">IPython</a></li>
                       <li><a href="https://irkernel.github.io/">IRkernel</a></li>
                       <li><a href="https://github.com/JuliaLang/IJulia.jl">IJulia</a></li>
-                      <li><a href="https://github.com/ipython/ipython/wiki/IPython-kernels-for-other-languages">Community maintained kernels</a></li>
+                      <li><a href="https://github.com/jupyter/jupyter/wiki/Jupyter-kernels">Community maintained kernels</a></li>
                     </ul>
                   </div>
                   <div class="dropdown col-lg-4 col-md-6 col-sm-6">
@@ -97,6 +97,7 @@ navbar_white: true
                       <li><a href="https://ipywidgets.readthedocs.io/en/latest/">IPyWidgets</a></li>
                       <li><a href="https://github.com/jupyter/jupyter-drive">Jupyter Drive</a></li>
                       <li><a href="https://github.com/jupyter/jupyter-sphinx-theme">Jupyter Sphinx Theme</a></li>
+                      <li><a href="http://jupyter-alabaster-theme.readthedocs.io/en/latest/">Jupyter Alabaster Theme</a></li>
                       <li><a href="http://jupyter-kernel-gateway.readthedocs.io/en/latest/">Kernel Gateway</a></li>
                       <li><a href="https://github.com/jupyter/nbviewer/">NbViewer</a></li>
                       <li><a href="https://github.com/jupyter/tmpnb">Tmpnb</a></li>


### PR DESCRIPTION
- update JupyterLab documentation link
- update Community maintained kernels link
- add Jupyter Alabaster Theme to deployment section

Currently IPython and IPyKernel have the same link? Should we remove one of the items or update the IPyKernel link to be more relevant? 