### PR TITLE
Refined JupyterCon Header

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -601,7 +601,7 @@ body {
 .jupytercon-button {
     display: block;
     text-align: center;
-    margin-top: 60px;
+    margin-top: 40px;
     margin-bottom: 20px;
 }
 .navbar-toggle > .white-icon-bar {

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@ navbar_jupytercon: true
             <div class="row">
                 <div class="col-md-12">
                     <img src="/assets/jupytercon-logo.svg" alt="Jupytercon announcement logo" id="jupytercon-logo" class="img-responsive"/>
-                    <h2 class="jupytercon-header">Announcing JupyterCon</h2>
                     <h3 class="jupytercon-subheader">August 22 - 25, 2017</h3>
                     <h3 class="jupytercon-subheader">New York, NY</h3>
                     <div class="jupytercon-button">


### PR DESCRIPTION
Removed the "Announcing JupyterCon" text from the home page since it has been some time since we announced the event. Done by request of @Ruv7.

#### Before
![screen shot 2017-06-14 at 10 19 03 am](https://user-images.githubusercontent.com/6437976/27145599-34d9186e-50eb-11e7-8a4c-5f8d80d94345.png)

#### After
![screen shot 2017-06-14 at 10 18 50 am](https://user-images.githubusercontent.com/6437976/27145608-3bed80cc-50eb-11e7-9e6e-fdb60d4d242f.png)
