### PR TITLE
size logos with css

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -296,7 +296,8 @@ body {
 }
 .companies .col img{
     display: block;
-    width: 100%
+    width: 100%;
+    max-height: 60px;
 }
 .greydout {
     -moz-opacity: .065;

--- a/index.html
+++ b/index.html
@@ -155,32 +155,32 @@ navbar_jupytercon: true
             <div class="row">
                 <h3 class="section-header">Currently in use at</h3>
                 <ul class="companies">
-                    <li class="col"><a href="http://www.google.com"><img src="assets/google.svg" class="greydout" alt="Google" height="45" width="130"></a></li>
-                    <li class="col"><a href="http://www.microsoft.com"><img src="assets/Microsoft.svg" class="greydout" alt="Microsoft" height="55" width="206"></a></li>
-                    <li class="col"><a href="http://www.ibm.com"><img src="assets/IBM.svg" class="greydout" alt="IBM" height="40" width="60"></a></li>
-                    <li class="col"><a href="http://www.bloomberg.com"><img src="assets/bloomberg.svg" class="greydout" alt="Bloomberg" height="45" width="222"></a></li>
-                    <li class="col"><a href="http://www.oreilly.com"><img src="assets/oreilly.svg" class="greydout" alt="OReilly" height="45" width="244"></a></li>
-                    <li class="col"><a href="http://continuum.io"><img src="assets/continuum.svg" class="greydout" alt="Continuum" height="60" width="102"></a></li>
-                    <li class="col"><a href="http://developer.rackspace.com"><img src="assets/rackspace.svg" class="greydout" alt="Rackspace" height="60" width="200"></a></li>
-                    <li class="col"><a href="http://www.soundcloud.com"><img src="assets/soundcloud.svg" class="greydout" alt="SoundCloud" height="82" width="144"></a></li>
-                    <li class="col"><a href="https://www.quantopian.com/"><img src="assets/quantopian.svg" class="greydout" alt="Quantopian" height="60" width="118"></a></li>
-                    <li class="col"><a href="http://www.netapp.com/us/"><img src="assets/netapp.svg" class="greydout" alt="NetApp" height="60" width="344"></a></li>
-                    <li class="col"><a href="http://software-carpentry.org"><img src="assets/carpentry.svg" class="greydout" alt="Carpentry" height="60" width="131"></a></li>
-                    <li class="col"><a href="https://www.janelia.org/"><img src="assets/janelia.svg" class="greydout" alt="Janelia" height="60" width="178"></a></li>
-                    <li class="col"><a href="http://codeneuro.org/"><img src="assets/codeneuro.svg" class="greydout" alt="CodeNeuro" height="60" width="296"></a></li>
-                    <li class="col"><a href=""><img src="assets/nsite.svg" class="greydout" alt="NSite" height="50" width="94"></a></li>
-                    <li class="col"><a href="https://cocalc.com/"><img src="assets/cocalc.svg" class="greydout" alt="CoCalc" height="50" width="94"></a></li>
-                    <li class="col"><a href="https://www.brynmawr.edu"><img src="assets/brynmawr.svg" class="greydout" alt="BrynMawr" height="60" width="72"></a></li>
-                    <li class="col"><a href="http://www.calpoly.edu"><img src="assets/calpoly.svg" class="greydout" alt="CalPoly" height="60" width="72"></a></li>
-                    <li class="col"><a href="http://www.berkeley.edu"><img src="assets/Berkeley.svg" class="greydout" alt="Berkeley" height="60" width="147"></a></li>
-                    <li class="col"><a href="http://www.sheffield.ac.uk/"><img src="assets/sheffield.svg" class="greydout" alt="Sheffield" height="60" width="137"></a></li>
-                    <li class="col"><a href="http://www.gwu.edu/"><img src="assets/washington.svg" class="greydout" alt="Washington" height="60" width="108"></a></li>
-                    <li class="col"><a href="http://www.clemson.edu/"><img src="assets/clemson.svg" class="greydout" alt="Clemson" height="60" width="150"></a></li>
-                    <li class="col"><a href="https://msu.edu/"><img src="assets/michigan-state.svg" class="greydout" alt="Michigan State University" height="60" width="200"></a></li>
-                    <li class="col"><a href="http://www.northwestern.edu/"><img src="assets/northwestern.svg" class="greydout" alt="Northwestern University" height="60" width="133"></a></li>
-                    <li class="col"><a href="http://www.nyu.edu"><img src="assets/NYU.svg" class="greydout" alt="NYU" height="60" width="133"></a></li>
-                    <li class="col"><a href="http://www.nasa.gov"><img src="assets/NASA.svg" class="greydout" alt="NASA" height="60" width="133"></a></li>
-                    <li class="col"><a href="http://ayasdi.com"><img src="assets/ayasdi.svg" class="greydout" alt="Ayasdi" height="60" width="282"></a></li>
+                    <li class="col"><a href="http://www.google.com"><img src="assets/google.svg" class="greydout" alt="Google"></a></li>
+                    <li class="col"><a href="http://www.microsoft.com"><img src="assets/Microsoft.svg" class="greydout" alt="Microsoft"></a></li>
+                    <li class="col"><a href="http://www.ibm.com"><img src="assets/IBM.svg" class="greydout" alt="IBM"></a></li>
+                    <li class="col"><a href="http://www.bloomberg.com"><img src="assets/bloomberg.svg" class="greydout" alt="Bloomberg"></a></li>
+                    <li class="col"><a href="http://www.oreilly.com"><img src="assets/oreilly.svg" class="greydout" alt="OReilly"></a></li>
+                    <li class="col"><a href="http://continuum.io"><img src="assets/continuum.svg" class="greydout" alt="Continuum"></a></li>
+                    <li class="col"><a href="http://developer.rackspace.com"><img src="assets/rackspace.svg" class="greydout" alt="Rackspace"></a></li>
+                    <li class="col"><a href="http://www.soundcloud.com"><img src="assets/soundcloud.svg" class="greydout" alt="SoundCloud"></a></li>
+                    <li class="col"><a href="https://www.quantopian.com/"><img src="assets/quantopian.svg" class="greydout" alt="Quantopian"></a></li>
+                    <li class="col"><a href="http://www.netapp.com/us/"><img src="assets/netapp.svg" class="greydout" alt="NetApp"></a></li>
+                    <li class="col"><a href="http://software-carpentry.org"><img src="assets/carpentry.svg" class="greydout" alt="Carpentry"></a></li>
+                    <li class="col"><a href="https://www.janelia.org/"><img src="assets/janelia.svg" class="greydout" alt="Janelia"></a></li>
+                    <li class="col"><a href="http://codeneuro.org/"><img src="assets/codeneuro.svg" class="greydout" alt="CodeNeuro"></a></li>
+                    <li class="col"><a href=""><img src="assets/nsite.svg" class="greydout" alt="NSite"></a></li>
+                    <li class="col"><a href="https://cocalc.com/"><img src="assets/cocalc.svg" class="greydout" alt="CoCalc"></a></li>
+                    <li class="col"><a href="https://www.brynmawr.edu"><img src="assets/brynmawr.svg" class="greydout" alt="BrynMawr"></a></li>
+                    <li class="col"><a href="http://www.calpoly.edu"><img src="assets/calpoly.svg" class="greydout" alt="CalPoly"></a></li>
+                    <li class="col"><a href="http://www.berkeley.edu"><img src="assets/Berkeley.svg" class="greydout" alt="Berkeley"></a></li>
+                    <li class="col"><a href="http://www.sheffield.ac.uk/"><img src="assets/sheffield.svg" class="greydout" alt="Sheffield"></a></li>
+                    <li class="col"><a href="http://www.gwu.edu/"><img src="assets/washington.svg" class="greydout" alt="Washington"></a></li>
+                    <li class="col"><a href="http://www.clemson.edu/"><img src="assets/clemson.svg" class="greydout" alt="Clemson"></a></li>
+                    <li class="col"><a href="https://msu.edu/"><img src="assets/michigan-state.svg" class="greydout" alt="Michigan State University"></a></li>
+                    <li class="col"><a href="http://www.northwestern.edu/"><img src="assets/northwestern.svg" class="greydout" alt="Northwestern University"></a></li>
+                    <li class="col"><a href="http://www.nyu.edu"><img src="assets/NYU.svg" class="greydout" alt="NYU"></a></li>
+                    <li class="col"><a href="http://www.nasa.gov"><img src="assets/NASA.svg" class="greydout" alt="NASA"></a></li>
+                    <li class="col"><a href="http://ayasdi.com"><img src="assets/ayasdi.svg" class="greydout" alt="Ayasdi"></a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
rather than having width/height set on each logo, which can distort aspect ratios on Firefox.

closes #209