### PR TITLE
remove codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,0 @@
-# These individuals will be automatically added as reviewers to any pull request
-# on this repo
-
-# These owners will be the default owners for everything in the repo.
-*       @cameronoelsen @ruv7 @carreau


### PR DESCRIPTION
@ellisonbg 

having a codeowner file **enforce** one the the owner to approve the pull-request.  meaning that no-one else can merge a trivial PR without the +1 or owner.