### PR TITLE
Add a presentation of Folium

### DIFF
--- a/assets/folium-example.py
+++ b/assets/folium-example.py
@@ -1,0 +1,3 @@
+from folium import Map
+
+Map(location=[34.6252978589571, -77.34580993652344], zoom_start=10)

--- a/widgets.html
+++ b/widgets.html
@@ -36,6 +36,12 @@ navbar_gray: true
     <div class="tabbable tabs-left">
       <ul class="nav nav-tabs">
         <li class="active">
+          <a href="#folium" data-toggle="tab">
+          <p>folium</p>
+          <p>Geo-spatial analytics</p>
+          </a>
+        </li>
+        <li>
           <a href="#ipyleaflet" data-toggle="tab">
           <p>ipyleaflet</p>
           <p>Geo-spatial analytics</p>
@@ -67,6 +73,32 @@ navbar_gray: true
         </li>
       </ul>
       <div class="tab-content">
+          <div class="tab-pane active" id="folium">
+            <div class="jupyter-widget-header">
+              <span class="gallery-title">folium</span>
+                <span>
+                  <a href="http://mybinder.org/repo/python-visualization/folium/notebooks/examples">
+                  <img class="img-scaling" src="assets/mybinder.svg" alt="Binder">
+                  </a>
+                  <a href="https://github.com/python-visualization/folium">
+                  <img class="img-scaling" src="assets/github.svg" alt="GitHub">
+                  </a>
+                </span>
+            </div>
+            <p>
+            A library for creating simple interactive maps with panning and
+            zooming, folium supports annotations such as polygons,
+            markers, clustered markes, and more generally any geojson-encoded geographical
+            data structure.
+            </p>
+            <h3>Example</h3>
+            {% highlight python %}{% include_relative assets/folium-example.py %}{% endhighlight %}
+            <h3>Installation</h3>
+            With conda:
+            {% highlight bash %}conda install folium{% endhighlight %}
+            With pip:
+            {% highlight bash %}pip install folium{% endhighlight %}
+        </div>
         <div class="tab-pane active" id="ipyleaflet">
           <div class="jupyter-widget-header">
             <span class="gallery-title">ipyleaflet</span>


### PR DESCRIPTION
After a few researches it seems to a be a better Python implementation of leaflet.js than Ipyleaflet (e.g. : it supports Mark cluster).
And since it wasn't presented in the Jupyter website I thought that only Ipyleaflet was able to do what I wanted and almost thought I should not use Jupyter. But after one day of researches I found that Jupyter, through Folium, could fit my needs.
So  I think Folium should be presentend on the Jupyter website as an alternative to Ipyleaflet.