### PR TITLE
Fix typos in about.html

### DIFF
--- a/about.html
+++ b/about.html
@@ -43,8 +43,9 @@ title: "About Us"
                     </p>
                     <p>
                         All online and in-person interactions and communications directly related to the project are covered by the
-                        <a href="https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md">Jupyter Code of Conduct</a>. This Code of Conduct sets expectations to enable a diverse community of
-                        user and contributors to participate in the project with respect and safety.
+                        <a href="https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md">Jupyter Code of Conduct</a>.
+                        This Code of Conduct sets expectations to enable a diverse community of
+                        users and contributors to participate in the project with respect and safety.
                     </p>
                 </div>
             </div>
@@ -59,7 +60,7 @@ title: "About Us"
                 <img src="assets/steering.svg" class="section-icon img-responsive" alt="steering committee icon">
                 <h3 class="col-sm-12 section-header">Steering Council</h3>
                 <p class="col-sm-12 support-paragraph">
-                    The role of the Jupyter Steering Council is to ensure, through working with and serving the broader Juputer community, 
+                    The role of the Jupyter Steering Council is to ensure, through working with and serving the broader Jupyter community, 
                     the long-term well-being of the project, both technically and as a community. The Jupyter Steering Council currently consists
                     of the following members (in alphabetical order).
                 </p>


### PR DESCRIPTION
Two typos: user -> users, Juputer -> Jupyter. Fixes #237.