### PR TITLE
update to refer to newer version of beakerx widgets

### DIFF
--- a/assets/beakerx-example.json
+++ b/assets/beakerx-example.json
@@ -5,8 +5,8 @@
         "d6371237-9b40-427e-9833-71cb25330855": {
             "model_name": "TableDisplayModel",
             "model_module": "beakerx",
-            "model_module_version": "0.6.2-widgets7b",
-            "view_module_version": "0.6.2-widgets7b",
+            "model_module_version": "0.6.3-widgets7b",
+            "view_module_version": "0.6.3-widgets7b",
             "state": {
                 "model": {
                     "columnOrder": [],


### PR DESCRIPTION
 this has a fix to prevent the widget from jumping down when window is narrow, plus a big performance fix.  here are comparison screenshots showing the bug visible on the current site, and then the fixed version:
![screen shot 2017-10-26 at 11 57 19 am](https://user-images.githubusercontent.com/963093/32063375-019fa3c8-ba45-11e7-9aa1-43e9cb88d7d1.png)
![screen shot 2017-10-26 at 11 57 53 am](https://user-images.githubusercontent.com/963093/32063391-0b7c3744-ba45-11e7-934f-aed08502988e.png)
