### PR TITLE
Try nicer urls. /about/ instead of /about.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bundle install
 cd into the root of this directory,
 
 ```
-bundle exec jekyll serve --baseurl ''
+bundle exec jekyll serve -w
 ```
 
 Open your browser to localhost:4000.

--- a/_config.yml
+++ b/_config.yml
@@ -15,3 +15,6 @@ markdown: kramdown
 highlighter: rouge
 
 exclude: [vendor]
+
+plugins:
+  - jekyll-redirect-from

--- a/about.html
+++ b/about.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "About Us"
+permalink: /about
 ---
 
 
@@ -57,7 +58,7 @@ title: "About Us"
     <div class="section-white top-section-border">
         <div class="container">
             <div class="row">
-                <img src="assets/steering.svg" class="section-icon img-responsive" alt="steering committee icon">
+            <img src="{{site.url}}/assets/steering.svg" class="section-icon img-responsive" alt="steering committee icon">
                 <h3 class="col-sm-12 section-header">Steering Council</h3>
                 <p class="col-sm-12 support-paragraph">
                     The role of the Jupyter Steering Council is to ensure, through working with and serving the broader Jupyter community, 
@@ -149,49 +150,50 @@ title: "About Us"
     <div class="section-grey">
         <div class="container">
             <div class="row">
-                <img src="assets/sponsors2.svg" class="section-icon img-responsive" alt="sponsors">
+                <img src="{{site.url}}/assets/sponsors2.svg" class="section-icon img-responsive" alt="sponsors">
                 <h3 class="col-sm-12 section-header">Sponsors</h3>
                 <p class="col-sm-12 support-paragraph">Project Jupyter receives direct funding from the following sources:</p>
                 <div class="col-xs-12 section-center">
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="http://helmsleytrust.org">
-                            <img src="assets/helmsley.svg" class="company-logo" alt="helmsley trust logo"/>                                   </a>
+                            <img src="{{site.url}}/assets/helmsley.svg" class="company-logo" alt="helmsley trust logo"/>
+                        </a>
                     </div>
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="http://www.sloan.org/">
-                            <img src="assets/alfred.svg" class="company-logo" alt="sloan logo"/>
+                            <img src="{{site.url}}/assets/alfred.svg" class="company-logo" alt="sloan logo"/>
                         </a>
                     </div>
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="https://www.moore.org/">
-                            <img src="assets/moore.svg" class="company-logo" alt="moore foundation logo"/>
+                            <img src="{{site.url}}/assets/moore.svg" class="company-logo" alt="moore foundation logo"/>
                         </a>
                     </div>
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="https://www.google.com/">
-                            <img src="assets/google-color.svg"  class="company-logo" alt="google logo"/>
+                            <img src="{{site.url}}/assets/google-color.svg"  class="company-logo" alt="google logo"/>
                         </a>
                     </div>
                 </div>
                 <div class="col-xs-12 section-center">
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="http://developer.rackspace.com/">
-                            <img src="assets/rackspace-color.svg" class="company-logo" alt="rackspace logo"/>
+                            <img src="{{site.url}}/assets/rackspace-color.svg" class="company-logo" alt="rackspace logo"/>
                         </a>
                     </div>
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="https://www.fastly.com/">
-                            <img src="assets/fastly.svg" class="company-logo" alt="fastly logo"/>
+                            <img src="{{site.url}}/assets/fastly.svg" class="company-logo" alt="fastly logo"/>
                         </a>
                     </div>
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="http://opendreamkit.org/">
-                            <img src="assets/EC-H2020.svg" class="company-logo" alt="EU logo"/>
+                            <img src="{{site.url}}/assets/EC-H2020.svg" class="company-logo" alt="EU logo"/>
                         </a>
                     </div>
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="http://www.microsoft.com/">
-                            <img src="assets/microsoft-color.svg" class="company-logo" alt="microsoft logo"/>
+                            <img src="{{site.url}}/assets/microsoft-color.svg" class="company-logo" alt="microsoft logo"/>
                         </a>
                     </div>
                 </div>
@@ -203,7 +205,7 @@ title: "About Us"
     <div class="section-white">
         <div class="container">
             <div class="row">
-                <img src="assets/institutional_partners2.svg" class="section-icon img-responsive" alt="institutional partners">
+                <img src="{{site.url}}/assets/institutional_partners2.svg" class="section-icon img-responsive" alt="institutional partners">
                 <h3 class="col-sm-12 section-header">Institutional Partners</h3>
                 <p class="col-sm-12 support-paragraph">
                     Institutional Partners are organizations that support the project by employing Jupyter Steering Council members.
@@ -212,32 +214,32 @@ title: "About Us"
                 <div class="col-xs-12 section-center">
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="http://continuum.io/">
-                            <img src="assets/continuum-color.svg" class="company-logo" height="60" width="200" alt="continuum.io logo">
+                            <img src="{{site.url}}/assets/continuum-color.svg" class="company-logo" height="60" width="200" alt="continuum.io logo">
                         </a>
                     </div>
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="http://www.bloomberg.com/">
-                            <img src="assets/bloomberg-color.svg" class="company-logo" alt="bloomberg logo">
+                            <img src="{{site.url}}/assets/bloomberg-color.svg" class="company-logo" alt="bloomberg logo">
                         </a>
                     </div>
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="http://techblog.netflix.com">
-                            <img src="assets/netflix-color.svg" class="company-logo" alt="netflix logo">
+                            <img src="{{site.url}}/assets/netflix-color.svg" class="company-logo" alt="netflix logo">
                         </a>
                     </div>
                     <div class="col-sm-3 col-xs-6 sponsor">
                         <a href="http://www.calpoly.edu/">
-                            <img src="assets/poly-color.svg" class="company-logo" alt="cal poly logo">
+                            <img src="{{site.url}}/assets/poly-color.svg" class="company-logo" alt="cal poly logo">
                         </a>
                     </div>
                     <div class="col-sm-3 col-sm-offset-4 col-xs-6 sponsor center-block">
                         <a href="http://www.berkeley.edu/">
-                            <img src="assets/berkeley-color.svg" class="company-logo" alt="UC Berkeley logo">
+                            <img src="{{site.url}}/assets/berkeley-color.svg" class="company-logo" alt="UC Berkeley logo">
                         </a>
                     </div>
                     <div class="col-sm-3 col-sm-offset-4 col-xs-6 sponsor center-block">
                         <a href="http://quantstack.net/">
-                            <img src="assets/quantstack-color.svg" class="company-logo" alt="QuantStack logo">
+                            <img src="{{site.url}}/assets/quantstack-color.svg" class="company-logo" alt="QuantStack logo">
                         </a>
                     </div>
                 </div>
@@ -249,7 +251,7 @@ title: "About Us"
     <div class="section-grey top-section-border">
         <div class="container">
             <div class="architecturedescription col-md-12">
-                <img src="assets/donations-icon2.svg" class="section-icon" alt="donations icon">
+                <img src="{{site.url}}/assets/donations-icon2.svg" class="section-icon" alt="donations icon">
                 <h3 class="section-header">Donations</h3>
                 <p id="support-paragraph">Jupyter will always be 100% open source software, free for all to use and
                 released under the liberal terms of the <a href="https://opensource.org/licenses/BSD-3-Clause">modified BSD license</a>. 
@@ -263,7 +265,9 @@ title: "About Us"
                 </p>
             </div>
             <div class="col-md-12 donate-box">
-                <a href="http://numfocus.org"><img id="numfocus-logo" src="assets/numfocus_logo.png" class="img-responsive center-block" alt="numfocus logo"></a>
+                <a href="http://numfocus.org">
+                  <img id="numfocus-logo" src="{{site.url}}/assets/numfocus_logo.png" class="img-responsive center-block" alt="numfocus logo">
+                </a>
                 <div id="donate-formatting">
                     <a href="https://www.flipcause.com/widget/MjI1OQ==" class="orange-button" id="donate-link">
                         Support Project Jupyter

--- a/community.html
+++ b/community.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Community
+permalink: /community
 ---
 
 <section>

--- a/documentation.html
+++ b/documentation.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Documentation
+permalink: /documentation
 ---
 
 

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: default
 title: Home
 navbar_jupytercon: true
+permalink: /
 ---
 
 <section>

--- a/install.html
+++ b/install.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Install
+permalink: /install
 ---
 
 <section>

--- a/widgets.html
+++ b/widgets.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Widgets
+permalink: /widgets
 ---
 
 <link href="css/gallery.css" rel="stylesheet">


### PR DESCRIPTION
I think that _easthetically_ it is better though there are drawback.
We don't control the webserver so no 301/302, but meta content rredirect
:-(, and it breaks `jekyll serve` (you can still use python http.server
though.

So it's like to _try_ that on this page, and see how it goes.