### PR TITLE
Revert back docs cards to blue.

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -21,7 +21,8 @@
 
 .docs-card-heading {
   padding: 16px;
-  background: #F27624;
+  /* color is on purpose not Jupyter Orange */
+  background: #1976D2;
   color: white;
   font-size: 14px;
   font-weight: normal;


### PR DESCRIPTION
Note that the blue here (`#1976D2`) is used nowhere else in css we load,
unlike the `#337ab7` blue (slightly darker) that we do use.

cc @ellisonbg 