### PR TITLE
Move the try and install button in preparation to JuypyterLab header.

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -303,6 +303,8 @@ body {
 .nb-desc {
     font-weight: 400;
     line-height: 1.5;
+    margin-top: 20px;
+    margin-bottom: 32px;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -56,21 +56,6 @@ permalink: /
     </div>
 </section>
 {% endif %}
-<section>
-    <div class="install-prompt">
-        <div class="container-fluid">
-            <div class="row">
-                <div class="col-xs-12">
-                    <h3 class="prompt-header">Ready to get started?</h3>
-                    <div>
-                        <a class="orange-button" href="https://try.jupyter.org/" target="_blank">Try it in your browser</a>
-                        <a class="orange-button install-button" href="install.html">Install the Notebook</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</section>
 <section id="about-notebook">
     <div class="section-white">
         <div class="notebook-preview">
@@ -84,6 +69,10 @@ permalink: /
                         <h4 class="nb-desc">The Jupyter Notebook is an open-source web application that allows you to create and share 
                             documents that contain live code, equations, visualizations and narrative text. Uses include: data cleaning 
                             and transformation, numerical simulation, statistical modeling, data visualization, machine learning, and much more.</h4>
+                    </div>
+                    <div>
+                        <a class="orange-button" href="https://try.jupyter.org/" target="_blank">Try it in your browser</a>
+                        <a class="orange-button install-button" href="install.html">Install the Notebook</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Having "Try" and "Install" in it's own section is confusing move then
closer to notebook.

This will be would be even more confusing once the Lab section will be
there.

![screen shot 2018-02-07 at 16 57 32](https://user-images.githubusercontent.com/335567/35949759-065037a4-0c28-11e8-8813-99b820631e23.png)
