### PR TITLE
remove some typos in documentation html

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -16,8 +16,8 @@ title: Documentation
               {%- for card in site.data.documentation -%}
                 <div class="col-lg-4 col-md-6 col-sm-6 docs-card-col">
                   <div class="docs-card">
-                    <div id="general-block" class="docs-card-heading">
-                      <h4 class="">{{card[0]}}</h4>
+                    <div class="docs-card-heading">
+                      <h4>{{card[0]}}</h4>
                     </div>
                     <div class="docs-card-body">
                       <ul>


### PR DESCRIPTION
- unused id in a repeated element
- empty class