### PR TITLE
Widgets: fix indentation issue in installation instructions for BeakerX

### DIFF
--- a/widgets.html
+++ b/widgets.html
@@ -290,7 +290,7 @@ jupyter nbextension enable --py --sys-prefix ipyvolume{% endhighlight %}
           {% highlight bash %}conda install -c conda-forge beakerx ipywidgets{% endhighlight %}
           With pip:
           {% highlight bash %}pip install beakerx
-          beakerx-install{% endhighlight %}
+beakerx-install{% endhighlight %}
         </div>
         <div class="tab-pane" id="jupyter-gmaps">
             <div class="jupyter-widget-header">


### PR DESCRIPTION
In PR #273 , I accidentally broke the alignment of the installation instructions for BeakerX. This fixes it.

Before:

<img width="857" alt="screen shot 2018-04-11 at 06 35 24" src="https://user-images.githubusercontent.com/1392879/38598111-fd447c54-3d52-11e8-8a92-7543638c63f0.png">

After:

<img width="865" alt="screen shot 2018-04-11 at 06 35 43" src="https://user-images.githubusercontent.com/1392879/38598115-02970f78-3d53-11e8-99c2-c127c04d36c1.png">
