### PR TITLE
Add cache busting for GH pages.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,7 +13,7 @@
     <meta property="og:image" content="http://jupyter.org/assets/homepage.png" />
     <!-- Bootstrap Core CSS -->
     <link rel="stylesheet" href="{{ "/css/bootstrap.min.css" | prepend: site.baseurl }}">
-    <link rel="stylesheet" href="{{ "/css/logo-nav.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ "/css/logo-nav.css" | prepend: site.baseurl }}?{{site.time | date: '%s%N'}}">
     <link rel="stylesheet" href="{{ "/css/cardlist.css" | prepend: site.baseurl }}">
     <link rel="stylesheet" href="{{ "/css/github-buttons.css" | prepend: site.baseurl }}">
     <link rel="icon" type="image/png" href="favicon.ico" />


### PR DESCRIPTION
We were running into the css being cached and that messing up style updates to the website. The PR uses the technique in this blog to fix the issues:

https://toddmotto.com/cache-busting-jekyll-github-pages

