### PR TITLE
JupyterHub page

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -5,7 +5,7 @@ head:
     - Documentation
     - title: NBViewer
       url: https://nbviewer.jupyter.org
+    - JupyterHub
     - Widgets
     - title: Blog
       url: https://blog.jupyter.org
-

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="{{ "/css/logo-nav.css" | prepend: site.baseurl }}?{{site.time | date: '%s%N'}}">
     <link rel="stylesheet" href="{{ "/css/cardlist.css" | prepend: site.baseurl }}">
     <link rel="stylesheet" href="{{ "/css/github-buttons.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ "/css/markdown_page.css" | prepend: site.baseurl }}">
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link href="{{site.baseurl}}/assets/apple-touch-icon.png" rel="apple-touch-icon" />
     <link href="{{site.baseurl}}/assets/apple-touch-icon-76x76.png" rel="apple-touch-icon" sizes="76x76" />

--- a/_layouts/page_md.html
+++ b/_layouts/page_md.html
@@ -1,0 +1,18 @@
+---
+layout: default
+---
+<div class="post">
+  <header class="post-header header header-grey">
+    <h2>{{ page.title }}</h2>
+    <p>{{ page.tagline }}</p>
+  </header>
+
+  <article class="post-content">
+    <div class="section-white top-section-border">
+      <div class="page_content container">
+        {{ content }}
+      </div>
+    </div>
+  </article>
+
+</div>

--- a/_layouts/page_md.html
+++ b/_layouts/page_md.html
@@ -3,7 +3,11 @@ layout: default
 ---
 <div class="post">
   <header class="post-header header header-grey">
+    {% if page.title_image %}
+    <img src="{{ page.title_image }}" class="title_image" />
+    {% else %}
     <h2>{{ page.title }}</h2>
+    {% endif %}
     <p>{{ page.tagline }}</p>
   </header>
 

--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -22,7 +22,8 @@ body {
 }
 
 .navbar-fixed-top .navbar-brand {
-    padding: 0 15px;
+    padding: 5px 0px;
+    margin-left: 15px;
 }
 
 .navbar-header .icon-bar {
@@ -52,7 +53,7 @@ body {
 
 .nav > li > a {
     font-size: 16px;
-    padding: 12px 16px 10px;
+    padding: 12px 12px 10px;
 }
 
 .nav > li > a:hover {
@@ -745,7 +746,11 @@ body {
 }
 
 .navbar-toggle > .white-icon-bar {
-    background-color: white;
+    background-color: black;
+}
+
+.navbar-fixed-top .navbar-collapse {
+    max-height: 440px;
 }
 
 .jupytercon-button {
@@ -912,8 +917,8 @@ body {
       margin-top: 4px;
     }
     .nav>li>a {
-        font-size: 13px;
         letter-spacing: .8px;
+        font-size: 13px;
         padding-left: 8px;
         padding-right: 8px;
     }
@@ -926,8 +931,25 @@ body {
     }
 }
 
+.navbar-brand {
+    height: 60px;
+    overflow: hidden;
+}
+
 /* Small devices (tablets, 768px and up) */
 @media(min-width:768px) {
+
+    .container {
+        margin-left:10px;
+        margin-right:10px;
+        width: 100%;
+    }
+
+    .navbar-right {
+        margin-right: 10px;
+    }
+
+
 
     .navbar-fixed-top .navbar-brand {
         padding: 15px 0;
@@ -949,6 +971,10 @@ body {
 }
 
 @media (max-width: 768px) {
+
+    
+
+
     p {
         font-size: 16px;
         font-weight: 400;
@@ -1027,6 +1053,10 @@ body {
 }
 
 @media(max-width: 992px) {
+    .navbar-brand {
+       width: 30px;
+    }
+
     .con-container {
         background-image: url('../assets/jupytercon-ny.png');
         background-repeat: no-repeat;

--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -257,7 +257,7 @@ body {
 /* Header section of each page */
 .header {
     padding-top: 42px;
-    padding-bottom: 42px; 
+    padding-bottom: 42px;
     text-align: center;
 }
 
@@ -937,6 +937,14 @@ body {
     }
     .navbar-toggle {
         margin-top: 20px;
+    }
+
+}
+
+/* So the nav bar doesn't overlap with the logo */
+@media (max-width: 1200px) {
+    .nav>li>a {
+      font-size: 12px;
     }
 }
 

--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -963,13 +963,6 @@ body {
 
 }
 
-/* So the nav bar doesn't overlap with the logo */
-@media (max-width: 1200px) {
-    .nav>li>a {
-      font-size: 12px;
-    }
-}
-
 @media (max-width: 768px) {
 
     

--- a/css/markdown_page.css
+++ b/css/markdown_page.css
@@ -1,0 +1,5 @@
+div.page_content img {
+  height:200px;
+  width: 60%;
+  margin: 0px 20%;
+}

--- a/css/markdown_page.css
+++ b/css/markdown_page.css
@@ -3,3 +3,13 @@ div.page_content img {
   width: 60%;
   margin: 0px 20%;
 }
+
+div.page_content {
+  max-width: 700px;
+}
+
+img.title_image {
+  max-height: 200px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}

--- a/hub.md
+++ b/hub.md
@@ -51,7 +51,7 @@ public URL.
 
 **[Zero to JupyterHub for Kubernetes](https://z2jh.jupyter.org)** deploys
 JupyterHub on Kubernetes using Docker, allowing it to be scaled and
-maintained efficiently for large numbers of users. Zero to JupyterHub
+maintained efficiently for **large numbers of users**. Zero to JupyterHub
 is a Helm Chart for deploying JupyterHub quickly, as well as a semi-complete
 guide to deploying and configuring your JupyterHub on Kubernetes.
 

--- a/hub.md
+++ b/hub.md
@@ -11,7 +11,7 @@ permalink: /hub
 ## What is JupyterHub?
 
 JupyterHub provides remote access to Jupyter servers on shared infrastructure
-in ordre to make computational environments and resources more accessible to
+in order to make computational environments and resources more accessible to
 students, researchers, and data scientists.
 
 JupyterHub runs in the cloud or on your own hardware, and makes it possible

--- a/hub.md
+++ b/hub.md
@@ -1,0 +1,19 @@
+---
+layout: page_md
+title: JupyterHub
+tagline: Provide tens, hundreds, or thousands of users access to Jupyter environments
+navbar_jupytercon: true
+cfp: true
+permalink: /hub
+---
+
+![](assets/hublogo.svg)
+
+## Provide remote access to Jupyter environments
+
+JupyterHub allows you to share a Jupyter environment with people at your local
+organization, or with anyone around the world.
+
+* [JupyterHub GitHub repository](https://github.com/jupyterhub/jupyterhub)
+* [Deploy JupyterHub on Kubernetes](https://z2jh.jupyter.org)
+* [Deploy JupyterHub on a single VM](https://tljh.jupyter.org)

--- a/hub.md
+++ b/hub.md
@@ -10,9 +10,11 @@ permalink: /hub
 
 ## What is JupyterHub?
 
-JupyterHub provides remote access to Jupyter servers on shared infrastructure
-in order to make computational environments and resources more accessible to
-students, researchers, and data scientists.
+JupyterHub brings the power of notebooks to groups of users. It gives
+users access to computational environments and resources without burdening
+the users with installation and maintenance tasks. Users - including students,
+researchers, and data scientists - can get their work done in their own
+workspaces on shared resources which can be managed efficiently by system administrators.
 
 JupyterHub runs in the cloud or on your own hardware, and makes it possible
 to serve a pre-configured data science environment to any user in the world.
@@ -21,12 +23,12 @@ academic courses, and large-scale infrastructure.
 
 ## Key features of JupyterHub
 
-**Flexible** - JupyterHub can be used to serve a variety of environments. It
+**Customizable** - JupyterHub can be used to serve a variety of environments. It
 supports dozens of kernels with the Jupyter server, and can be used to serve
 a variety of user interfaces including the Jupyter Notebook, Jupyter Lab,
 RStudio, nteract, and more.
 
-**Secure** - JupyterHub can be configured with authentication in order to
+**Flexible** - JupyterHub can be configured with authentication in order to
 provide access to a subset of users. Authentication is pluggable, supporting
 a number of authentication protocols (such as OAuth and GitHub).
 
@@ -36,34 +38,38 @@ with up to tens of thousands of users.
 
 **Portable** - JupyterHub is entirely open-source and designed
 to be run on a variety of infrastructure. This includes commercial cloud
-providers, virtual machines, even your own laptop hardware.
+providers, virtual machines, or even your own laptop hardware.
+
+The foundational JupyterHub code and technology can be found in the [JupyterHub
+repository](https://github.com/jupyterhub/jupyterhub). This repository and the
+[JupyterHub documentation](https://jupyterhub.readthedocs.io/)
+contain more information about the internals of JupyterHub, its customization, and its
+configuration.
 
 ## Deploy a JupyterHub
 
 The Jupyter Community curates two JupyterHub "distributions" for deploying
 in the cloud. Follow the links below for more information.
 
-**[The Littlest JupyterHub](https://tljh.jupyter.org)** is a lightweight
-method to install JupyterHub on a **single virtual machine**. The TLJH
-guide has information on creating a VM on several cloud providers, as well
-as installing and customizing JupyterHub so that users may access it at a
-public URL.
-
 **[Zero to JupyterHub for Kubernetes](https://z2jh.jupyter.org)** deploys
 JupyterHub on Kubernetes using Docker, allowing it to be scaled and
 maintained efficiently for **large numbers of users**. Zero to JupyterHub
-is a Helm Chart for deploying JupyterHub quickly, as well as a semi-complete
+is a Helm Chart for deploying JupyterHub quickly, as well as a
 guide to deploying and configuring your JupyterHub on Kubernetes.
 
-**[The JupyterHub repository](https://github.com/jupyterhub/jupyterhub)**
-contains more information about the internals of JupyterHub and how to
-deploy it on more custom setups (such as your own laptop).
+**[The Littlest JupyterHub](https://tljh.jupyter.org)**, a recent and evolving
+distribution designed for smaller deployments, is a lightweight
+method to install JupyterHub on a **single virtual machine**. The Littlest
+JupyterHub (also known as TLJH), provides a
+guide with information on creating a VM on several cloud providers, as well
+as installing and customizing JupyterHub so that users may access it at a
+public URL.
 
 ## Join the community
 
-JupyterHub is an open-source and community-driven project. We'd love for you
-to join our community and contribute code, time, comments, or just
-appreciation.
+Like all Project Jupyter efforts, JupyterHub is an
+open-source and community-driven project. We'd love for you
+to join our community and contribute code, time, comments, or appreciation.
 
 **[The JupyterHub Gitter Channel](https://gitter.im/jupyterhub/jupyterhub)**
 is a place where the JupyterHub community discuses developments in the

--- a/hub.md
+++ b/hub.md
@@ -1,19 +1,70 @@
 ---
 layout: page_md
 title: JupyterHub
-tagline: Provide tens, hundreds, or thousands of users access to Jupyter environments
+title_image: assets/hublogo.svg
+tagline: A multi-user version of the notebook designed for companies, classrooms and research labs
 navbar_jupytercon: true
 cfp: true
 permalink: /hub
 ---
 
-![](assets/hublogo.svg)
+## What is JupyterHub?
 
-## Provide remote access to Jupyter environments
+JupyterHub provides remote access to Jupyter servers on shared infrastructure
+in ordre to make computational environments and resources more accessible to
+students, researchers, and data scientists.
 
-JupyterHub allows you to share a Jupyter environment with people at your local
-organization, or with anyone around the world.
+JupyterHub runs in the cloud or on your own hardware, and makes it possible
+to serve a pre-configured data science environment to any user in the world.
+It is customizable and scalable, and is suitable for small and large teams,
+academic courses, and large-scale infrastructure.
 
-* [JupyterHub GitHub repository](https://github.com/jupyterhub/jupyterhub)
-* [Deploy JupyterHub on Kubernetes](https://z2jh.jupyter.org)
-* [Deploy JupyterHub on a single VM](https://tljh.jupyter.org)
+## Key features of JupyterHub
+
+**Flexible** - JupyterHub can be used to serve a variety of environments. It
+supports dozens of kernels with the Jupyter server, and can be used to serve
+a variety of user interfaces including the Jupyter Notebook, Jupyter Lab,
+RStudio, nteract, and more.
+
+**Secure** - JupyterHub can be configured with authentication in order to
+provide access to a subset of users. Authentication is pluggable, supporting
+a number of authentication protocols (such as OAuth and GitHub).
+
+**Scalable** - JupyterHub is container-friendly, and can be deployed with
+modern-day container technology. It also runs on Kubernetes, and can run
+with up to tens of thousands of users.
+
+**Portable** - JupyterHub is entirely open-source and designed
+to be run on a variety of infrastructure. This includes commercial cloud
+providers, virtual machines, even your own laptop hardware.
+
+## Deploy a JupyterHub
+
+The Jupyter Community curates two JupyterHub "distributions" for deploying
+in the cloud. Follow the links below for more information.
+
+**[The Littlest JupyterHub](https://tljh.jupyter.org)** is a lightweight
+method to install JupyterHub on a **single virtual machine**. The TLJH
+guide has information on creating a VM on several cloud providers, as well
+as installing and customizing JupyterHub so that users may access it at a
+public URL.
+
+**[Zero to JupyterHub for Kubernetes](https://z2jh.jupyter.org)** deploys
+JupyterHub on Kubernetes using Docker, allowing it to be scaled and
+maintained efficiently for large numbers of users. Zero to JupyterHub
+is a Helm Chart for deploying JupyterHub quickly, as well as a semi-complete
+guide to deploying and configuring your JupyterHub on Kubernetes.
+
+**[The JupyterHub repository](https://github.com/jupyterhub/jupyterhub)**
+contains more information about the internals of JupyterHub and how to
+deploy it on more custom setups (such as your own laptop).
+
+## Join the community
+
+JupyterHub is an open-source and community-driven project. We'd love for you
+to join our community and contribute code, time, comments, or just
+appreciation.
+
+**[The JupyterHub Gitter Channel](https://gitter.im/jupyterhub/jupyterhub)**
+is a place where the JupyterHub community discuses developments in the
+JupyterHub technology, as well as best-practices in deploying and debugging.


### PR DESCRIPTION
This adds a JupyterHub page to the Jupyter website. It adds minimal stylistic changes, basically just enough to accomplish the same design using Jekyll templates and markdown instead of hard-coded HTML.

I'm happy to iterate on design-y stuff later on, but IMO the important thing for this PR is "do we like the content". This landing page should be thought of as a high-level overview of what JupyterHub is and who it could be useful for, as well as links to point people in the right direction for deploying.

Happy to either iterate on this PR or merge and spot-check later