### PR TITLE
try link to old repo

### DIFF
--- a/_data/try.yml
+++ b/_data/try.yml
@@ -10,7 +10,7 @@
     JupyterLab is the new interface for Jupyter notebooks and is ready for testing.
     Give it a try!
   logo: jupyter.png
-  url: https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/master?urlpath=lab%2Ftree%2Fdemo%2FLorenz.ipynb
+  url: https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/8b4372?urlpath=lab%2Ftree%2Fdemo%2FLorenz.ipynb
 
 - title: Try Jupyter with Julia
   description: |
@@ -29,4 +29,3 @@
     A basic example of using Jupyter with C++
   logo: Cpp.svg
   url: https://mybinder.org/v2/gh/QuantStack/xeus-cling/8e941852143e59d4d2400a4da9673b092cddf10e?filepath=notebooks/xcpp.ipynb
-


### PR DESCRIPTION
This is a temporary swap to point the `jupyterlab-demo` link to a non-master version.

Once it's switched, I'll unban, then build jupyterlab-demo, then we can switch this back.

cc @Carreau @ellisonbg @Ruv7 as I'm not sure who else has merge rights on this repo...