### PR TITLE
Adding a link to The Best Jupyter Notebook Videos

### DIFF
--- a/_data/documentation.yml
+++ b/_data/documentation.yml
@@ -3,6 +3,7 @@
 General:
   Project-wide Documentation: https://jupyter.readthedocs.io
   Contributing to Jupyter: https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html
+  Jupyter Videos: https://PythonLinks.info/jupyter-notebook
 
 User Interfaces:
   JupyterLab: https://jupyterlab.readthedocs.io/en/latest/


### PR DESCRIPTION
PythonLinks.info organizes Python Videos from the best Python conferences into a tree of categories and ranks them by up votes versus total votes.  The Jupyter Notebook branch of the tree starts with the JupyterCon Keynote, and currently has 65 Jupyter videos organized into the following tree of subcategories:

Technology
 - Dashboards
-    Devops

Teaching and Learning
-     Teaching

Data Science

Extending Jupyter Notebook,
- Visualizations
-  Machine Learning
 - Libraries

Applications 

Skills
- Managing Teams
 
The talks come from many different conferences.  You can see the full list of conferences here:
https://pythonlinks.info/conferences-and-channels

Features

You can search the tree, and the results are displayed as a tree.

There are usually no more than about 7 items in any category. This is very good from a human factors point of view.
PythonLinks.info works well on cell phones. Swipe left, right up or down to navigate the tree.
 On the desktop, to navigate the tree, use the arrow keys or the mouse scroll wheel.

Currently 710 videos are indexed, I add about a conference of 50 videos every week.

Not everyone watches videos, but those who do really like having videos on the same topic located in the same category, and ranked by upvotes versus total votes.

And of course, at the root of the tree, PythonLinks.info, you will find the 10 best overall videos.

Since you are experts on Jupyter Noteooks, please let me know if there are any other videos, or conferences you would recommend that I include in the Jupyter Noteooks branch of the tree.