### PR TITLE
Remove tmpnb from the architecture diagram.

### DIFF
--- a/generateGraph.py
+++ b/generateGraph.py
@@ -15,7 +15,6 @@ REPOS = [
     ("ipython", "ipyparallel"), 
     ("jupyter", "nbconvert"), 
     ("jupyter", "nbformat"), 
-    ("jupyter", "tmpnb"),
     ("jupyter", "nbgrader"),
     ("jupyter", "qtconsole") 
 ]


### PR DESCRIPTION
Remove tmpnb from the Jupyter architecture diagram because it was deprecated in jupyter/tmpnb#294