### PR TITLE
Fix layout on try.jupyter.org

### DIFF
--- a/css/cardlist.css
+++ b/css/cardlist.css
@@ -28,7 +28,7 @@
 }
 
 .card-heading h4 {
-  font-size: 1.8em;
+  font-size: 1.6em;
 }
 
 .card-body {
@@ -70,7 +70,7 @@ a.try-link:visited {
 
 /* try cards need to be a little taller */
 .cardlist-card.try-card {
-  height: 280px;
+  height: 320px;
 }
 
 /* shrink-to-fit logos */


### PR DESCRIPTION
• Made the cards taller
• Made `<h4>` smaller so we can fit 'Try Jupyter with Python' in one line
<img width="992" alt="screenshot 2018-10-20 15 36 33" src="https://user-images.githubusercontent.com/19514207/47252862-f28b0e00-d47d-11e8-8adb-0ca3aac3c3f4.png">

Fixes #311 