### PR TITLE
Add navigation link to Enterprise Gateway

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -9,6 +9,9 @@ head:
       url: https://nbviewer.jupyter.org
       newpage: true
     - JupyterHub
+    - title: Enterprise Gateway
+      # full url added as eg is an external website
+      url: https://jupyter.org/enterprise_gateway
     - Widgets
     - title: Blog
       url: https://blog.jupyter.org


### PR DESCRIPTION
Add navigation link to Jupyter Enterprise Gateway project, see sample generated html view below

![image](https://user-images.githubusercontent.com/382917/51273323-4627cd80-1981-11e9-8ef5-f151fcb54f92.png)
