### PR TITLE
Deprecate github.com/jupyter/help repo

### DIFF
--- a/_includes/community_lists.html
+++ b/_includes/community_lists.html
@@ -8,11 +8,11 @@
                             <img src="assets/github.svg" class="resource-logo" alt="github icon">
                         </div>
                         <div class="col-md-8 resource-text">
-                            <h3 class="resource-name">Jupyter on GitHub</h3>
-                            <p class="resource-desc">A GitHub repository to ask general questions about Jupyter software.</p>
+                            <h3 class="resource-name">Jupyter Discourse</h3>
+                            <p class="resource-desc">A place for the community to ask general questions about Jupyter software.</p>
                         </div>
                         <div class="col-md-2 resource-button">
-                            <a href="https://github.com/jupyter/help">View</a>
+                            <a href="http://discourse.jupyter.org/">View</a>
                         </div>
                     </div>
                 </div>

--- a/community.md
+++ b/community.md
@@ -14,7 +14,7 @@ or simply sharing your work with your colleagues and friends.
 ## Join the Jupyter community
 
 If you're interested in joining the Jupyter community (yay!) we recommend
-checking out the Jupyter [Contributing guide](https://github.com/jupyter/help/blob/master/CONTRIBUTING.md). This contains
+checking out the Jupyter [Contributing guide](TBD WHERE THIS NOW LIVES). This contains
 information about the different projects in the Jupyter ecosystem, the tools
 and skills that are useful for each project, and other ways that you can
 become a part of the Jupyter community.

--- a/community.md
+++ b/community.md
@@ -14,10 +14,11 @@ or simply sharing your work with your colleagues and friends.
 ## Join the Jupyter community
 
 If you're interested in joining the Jupyter community (yay!) we recommend
-checking out the Jupyter [Contributing guide](TBD WHERE THIS NOW LIVES). This contains
-information about the different projects in the Jupyter ecosystem, the tools
-and skills that are useful for each project, and other ways that you can
-become a part of the Jupyter community.
+checking out the Jupyter [Contributing
+guide](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).
+This contains information about the different projects in the Jupyter ecosystem,
+the tools and skills that are useful for each project, and other ways that you
+can become a part of the Jupyter community.
 
 ### JupyterDays, JupyterCon, and other events
 


### PR DESCRIPTION
* [x] Point to discourse.jupyter.org instead of github.com/jupyter/help
* [x] Link to the new location of the general "contributing to Jupyter guide" (TBD where it should live)

See https://discourse.jupyter.org/t/sunset-the-github-repo-jupyter-help/548/10 for discussion