### PR TITLE
Update community list to link to GitHub

### DIFF
--- a/_includes/community_lists.html
+++ b/_includes/community_lists.html
@@ -8,11 +8,11 @@
                             <img src="assets/github.svg" class="resource-logo" alt="github icon">
                         </div>
                         <div class="col-md-8 resource-text">
-                            <h3 class="resource-name">Jupyter Discourse</h3>
+                            <h3 class="resource-name">Jupyter GitHub</h3>
                             <p class="resource-desc">A place for the community to ask general questions about Jupyter software.</p>
                         </div>
                         <div class="col-md-2 resource-button">
-                            <a href="http://discourse.jupyter.org/">View</a>
+                            <a href="https://github.com/jupyter/">View</a>
                         </div>
                     </div>
                 </div>

--- a/_includes/community_lists.html
+++ b/_includes/community_lists.html
@@ -9,7 +9,7 @@
                         </div>
                         <div class="col-md-8 resource-text">
                             <h3 class="resource-name">Jupyter GitHub</h3>
-                            <p class="resource-desc">A place for the community to ask general questions about Jupyter software.</p>
+                            <p class="resource-desc">A place where the community collaborates on the development of Jupyter software.</p>
                         </div>
                         <div class="col-md-2 resource-button">
                             <a href="https://github.com/jupyter/">View</a>


### PR DESCRIPTION
The first link from the list was point to "Jupyter Discourse" same as the second link even though it has the GitHub icon (this is confusing I would expect to go to GitHub if I see the GitHub icon).
I have updated the link to point to Jupyter GitHub.