### PR TITLE
Add .well-known/security.txt

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,2 @@
+Contact: mailto:security@ipython.org
+Encryption: https://jupyter-notebook.readthedocs.io/en/stable/_downloads/ipython_security.asc

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ markdown: kramdown
 highlighter: rouge
 
 exclude: [vendor]
+include: [".well-known"]
 
 plugins:
   - jekyll-redirect-from


### PR DESCRIPTION
This PR addresses the easiest part of the conversation at https://discourse.jupyter.org/t/responsible-vulnerability-reporting/655/3 by adding vulnerability reporting metadata to `https://jupyter.org/.well-known/security.txt` per the draft RFC spec.

I'll open a separate PR adding text to the website itself. It'll likely take more discussion about where it should appear.