### PR TITLE
Add vulerability reporting info to community page

### DIFF
--- a/community.md
+++ b/community.md
@@ -43,4 +43,8 @@ a way that makes the community thrive.
 Below is a short list of gitter channels, email listservs, and github repositories
 where you can get involved. **We always welcome participation in the Jupyter community**.
 
+## Report vulnerabilities
+
+If you believe you've found a security vulnerability in a Jupyter project, please report it to [security@ipython.org](mailto:security@ipython.org). If you prefer to encrypt your security reports, you can use [this PGP public key](https://jupyter-notebook.readthedocs.io/en/stable/_downloads/ipython_security.asc).
+
 {% include community_lists.html %}


### PR DESCRIPTION
Complement to #334 for https://discourse.jupyter.org/t/responsible-vulnerability-reporting/655

I took a first pass at where the text might go on the site. I'm happy to change it.