### PR TITLE
Fix insecure Twitter widget in site footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -36,4 +36,4 @@
     <script src="{{site.baseurl}}/js/bootstrap.min.js"></script>
     <script src="{{site.baseurl}}/js/architecture.js"></script>
     <script src="{{site.baseurl}}/js/simon.js"></script>
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^https:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^https:/.test(d.location)?'https':'http';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>


### PR DESCRIPTION
This ternary had the `exprIfTrue` and `exprIfFalse` (terms from [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator)) transposed:

```
p=/^https:/.test(d.location)?'https':'http';
```

Using this, if the site is loaded as HTTPS, then the widget will be loaded as HTTP. If the site is loaded as HTTP, the widget will be loaded as HTTPS. This is the opposite of what we want.