### PR TITLE
Updated the installation page to match the documentation in the JupyterLab repo

### DIFF
--- a/install.md
+++ b/install.md
@@ -27,7 +27,7 @@ If you use `pip`, you can install it with:
 pip install jupyterlab
 ```
 
-If installing using `pip install --user`, you must add the user-level `bin` directory to your `PATH` environment variable in order to launch `jupyter lab`.
+If installing using `pip install --user`, you must add the user-level `bin` directory to your `PATH` environment variable in order to launch `jupyter lab`. If you are using a Unix derivative (FreeBSD, GNU / Linux, OS X), you can achieve this by using ``export PATH="$HOME/.local/bin:$PATH"`` command.
 
 ## Getting started with the classic Jupyter Notebook
 


### PR DESCRIPTION
Hi,
The [installation guide](https://github.com/jupyterlab/jupyterlab/blob/master/README.md) in the JupyterLab repo recently got updated. It is a small change but I believe it is a useful explanation for beginners. So, I updated the installation page to mirror the update.

I highlighted the part I updated:
<img width="963" alt="Screen Shot 2020-05-06 at 11 46 05 PM" src="https://user-images.githubusercontent.com/10498874/81252453-f6e13280-8ff3-11ea-8c28-035cc3a048a8.png">

