### PR TITLE
Add a link to the TypeScript widget cookiecutter

### DIFF
--- a/widgets.html
+++ b/widgets.html
@@ -391,23 +391,28 @@ jupyter nbextension enable --py --sys-prefix gmaps{% endhighlight %}
 
         <div class="tab-pane" id="cookiecutter">
           <div class="jupyter-widget-header">
-            <span class="gallery-title">widget cookiecutter</span>
+            <span class="gallery-title">widget cookiecutters</span>
             <span>
-              <a href="https://github.com/jupyter/widget-cookiecutter">
+              <a href="https://github.com/jupyter-widgets/widget-cookiecutter">
+              <img class="img-scaling" src="assets/github.svg" alt="GitHub">
+              </a>
+              <a href="https://github.com/jupyter-widgets/widget-ts-cookiecutter">
               <img class="img-scaling" src="assets/github.svg" alt="GitHub">
               </a>
             </span>
           </div>
           <p>
           The Jupyter widget framework is extensible and enables developers to create custom
-          widget libraries and bindings for visualization libraries of the JavaScript ecosystem.
+          widget libraries and bindings for visualization libraries of the JavaScript and TypeScript ecosystem.
           </p>
           <p>
-          The <code>cookiecutter</code> project helps widget authors get up to speed with the
-          packaging and distribution of Jupyter interactive widgets.
+          The <code>cookiecutter</code> projects help widget authors get up to speed with the
+          packaging and distribution of Jupyter interactive widgets, in
+          <a href="https://github.com/jupyter/widget-cookiecutter">JavaScript</a> and
+          <a href="https://github.com/jupyter/widget-ts-cookiecutter">TypeScript</a>.
           </p>
           <p>
-          It produces a base project for a Jupyter interactive widget library following the current best practices.
+          They produce a base project for a Jupyter interactive widget library following the current best practices.
           An implementation for a placeholder "Hello World" widget is provided. Following these practices will
           help make your custom widgets work in static web pages (like the examples of this page) and be compatible
           with future versions of Jupyter.


### PR DESCRIPTION
Add link to the TypeScript widget cookiecutter, so both cookiecutter projects are mentioned on the Widgets page: https://jupyter.org/widgets

![image](https://user-images.githubusercontent.com/591645/87296319-dc04d000-c506-11ea-9e60-60c753f5feaa.png)
