### PR TITLE
Fix typo in the widget cookiecutter links

### DIFF
--- a/widgets.html
+++ b/widgets.html
@@ -408,8 +408,8 @@ jupyter nbextension enable --py --sys-prefix gmaps{% endhighlight %}
           <p>
           The <code>cookiecutter</code> projects help widget authors get up to speed with the
           packaging and distribution of Jupyter interactive widgets, in
-          <a href="https://github.com/jupyter/widget-cookiecutter">JavaScript</a> and
-          <a href="https://github.com/jupyter/widget-ts-cookiecutter">TypeScript</a>.
+          <a href="https://github.com/jupyter-widgets/widget-cookiecutter">JavaScript</a> and
+          <a href="https://github.com/jupyter-widgets/widget-ts-cookiecutter">TypeScript</a>.
           </p>
           <p>
           They produce a base project for a Jupyter interactive widget library following the current best practices.


### PR DESCRIPTION
Follow-up to https://github.com/jupyter/jupyter.github.io/pull/373.

There was a typo in the links to the widget cookiecutters (linking to the wrong GitHub organization).

This PR fixes it.