### PR TITLE
Update contributing guide url

### DIFF
--- a/_data/documentation.yml
+++ b/_data/documentation.yml
@@ -2,7 +2,7 @@
 
 General:
   Project-wide Documentation: https://jupyter.readthedocs.io
-  Contributing to Jupyter: https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html
+  Contributing to Jupyter: https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html
 
 User Interfaces:
   JupyterLab: https://jupyterlab.readthedocs.io/en/latest/

--- a/_includes/community_lists.html
+++ b/_includes/community_lists.html
@@ -124,7 +124,7 @@
                             <p class="resource-desc">Contribution guidelines</p>
                         </div>
                         <div class="col-md-2 resource-button">
-                            <a href="https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html">View</a>
+                            <a href="https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html">View</a>
                         </div>
                     </div>
                 </div>

--- a/community.md
+++ b/community.md
@@ -15,7 +15,7 @@ or simply sharing your work with your colleagues and friends.
 
 If you're interested in joining the Jupyter community (yay!) we recommend
 checking out the Jupyter [Contributing
-guide](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).
+guide](https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html).
 This contains information about the different projects in the Jupyter ecosystem,
 the tools and skills that are useful for each project, and other ways that you
 can become a part of the Jupyter community.


### PR DESCRIPTION
The page formerly at

https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html

is now at

https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html

This pull request fixes the three occurrences on the Jupyter website.