### PR TITLE
Update JupyterCon banner to just link to conference site

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -213,6 +213,8 @@ body {
 .con-title {
     float: right;
     clear: both;
+    /* Make the logo image stand out from the background slightly */
+    filter: drop-shadow(0px 0px 8px rgba(0,0,0,0.3));
 }
 
 .con-subtitle {

--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -200,7 +200,7 @@ body {
     background-image: url('../assets/jupytercon-planet.jpg');
     background-size: 100%;
     background-repeat: no-repeat;
-    min-height: 500px;
+    min-height: 300px;
     text-align: right;
 }
 

--- a/index.html
+++ b/index.html
@@ -14,11 +14,7 @@ permalink: /
                     <div class="col-lg-8 con-content md-offset-2">	
                         <div class="con-date">October 5-17th</div>	
                         <img class="con-title img-responsive" srcset="assets/jupytercon-logo.png, assets/jupytercon-logo-white.png" />	
-                        <h2 class="con-subtitle">JupyterCon 2020 Call For Proposals</h2>
-                        <div class="con-copy">	
-                                Due <s>Mon, July 20</s> Wed, July 22
-                        </div>	
-                        <a class="orange-button con-button" href="https://jupytercon.com/talk-poster-cfp/" target="_blank">Learn more</a>	
+                        <a class="orange-button con-button" href="https://jupytercon.com/" target="_blank">Learn more</a>	
                     </div>	
                 </div>	
             </div>	


### PR DESCRIPTION
Delete the reference to the call for proposals now it is over.