### PR TITLE
PR: Update JLab version and point binder to latest 2.2.7

### DIFF
--- a/_data/try.yml
+++ b/_data/try.yml
@@ -10,7 +10,7 @@
     JupyterLab is the new interface for Jupyter notebooks and is ready for general use.
     Give it a try!
   logo: jupyter.png
-  url: https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/try.jupyter.org?urlpath=lab
+  url: https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/master?urlpath=lab/tree/demo
 
 - title: Try Jupyter with Julia
   description: |

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ permalink: /
                         <img class="img-responsive" src="assets/labpreview.png" id="portal" alt="examples of jupyterlab workspaces in single document and multiple document workspaces"/>
                     </div>
                     <div class="col-md-6 nb-highlight-text">
-                        <h3>JupyterLab 1.0: Jupyter’s Next-Generation Notebook Interface</h3>
+                        <h3>JupyterLab 2.0: Jupyter’s Next-Generation Notebook Interface</h3>
                         <h4 class="nb-desc">JupyterLab is a web-based interactive development environment for Jupyter notebooks, code, and data. JupyterLab is flexible: configure and arrange the user interface to support a wide range of workflows in data science, scientific computing, and machine learning. JupyterLab is extensible and modular: write plugins that add new components and integrate with existing ones.</h4>
                         <div class="button-container">
                             <a class="orange-button" href="try">Try it in your browser</a>


### PR DESCRIPTION
Fixes https://github.com/jupyter/jupyter.github.io/issues/376

Pointed binder to the jupyter-demo repo

<img width="1422" alt="Screen Shot 2020-09-13 at 14 07 32" src="https://user-images.githubusercontent.com/3627835/93026340-ee64be00-f5ca-11ea-9cd0-df40c700328b.png">

https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/master?urlpath=lab/tree/demo

<img width="1440" alt="Screen Shot 2020-09-13 at 14 24 16" src="https://user-images.githubusercontent.com/3627835/93026608-d2fab280-f5cc-11ea-85ad-fc018d5f5598.png">
