### PR TITLE
Make JupyterCon banner more readable with dropshadow.

### DIFF
--- a/css/logo-nav.css
+++ b/css/logo-nav.css
@@ -213,7 +213,10 @@ body {
 .con-title {
     float: right;
     clear: both;
-    /* Make the logo image stand out from the background slightly */
+}
+
+.dropshadow {
+    /* Make the foreground stand out from the background slightly */
     filter: drop-shadow(0px 0px 8px rgba(0,0,0,0.3));
 }
 
@@ -227,12 +230,15 @@ body {
 
 .con-program {
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
-    font-size: 30px;
     line-height: 34px;
     color: #FFFFFF;
     float: right;
     margin-right: 10px;
     margin-bottom: -10px
+}
+
+.con-program p {
+    font-weight: normal;
 }
 
 .con-date {

--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@ div#countdown {
 </section>
 <script>
 // Set the date we're counting down to
-var countDownDate = new Date("Oct 9, 2020 00:00:00").getTime();
+var countDownDate = new Date(Date.UTC(2020, 9, 5, 9, 0, 0)).getTime();
 
 // Update the count down every 1 second
 timer = function() {

--- a/index.html
+++ b/index.html
@@ -26,13 +26,13 @@ div#countdown {
             <div class="col-md-12">	
                 <div class="con-container img-responsive">	
                     <div class="col-lg-8 con-content md-offset-2">	
-                        <div class="con-date">October 5-17th</div>	
-                        <img class="con-title img-responsive" srcset="assets/jupytercon-logo.png, assets/jupytercon-logo-white.png" />	
+                        <div class="con-date dropshadow">October 5–17</div>	
+                        <img class="con-title dropshadow img-responsive" srcset="assets/jupytercon-logo.png, assets/jupytercon-logo-white.png" />	
                         <div class="con-program">
-                        <p>5-9 October: Tutorials – 12-16 October: Conference – 17 October: Sprints</p>
+                            <p class="dropshadow">Tutorials Oct 5–9 · Conference Oct 12–16 · Sprints 17 Oct</p>
                         </div>
                         <a class="orange-button con-button" href="https://jupytercon.com/" target="_blank">Learn more</a>	
-                        <div id="countdown"></div>
+                        <div id="countdown" class="dropshadow"></div>
                     </div>	
                 </div>	
             </div>	


### PR DESCRIPTION
The dropshadow adds just a small amount of contrast so you can read the text even on the light parts of the background. Also tweak the text slightly for readability and simplicity. Also fix the counter to count to the start of tutorials, not to the end of tutorials.

Before: 
<img width="857" alt="Screen Shot 2020-10-01 at 9 59 24 PM" src="https://user-images.githubusercontent.com/192614/94890464-26298d80-0434-11eb-9972-966f16aa8c10.png">

After:

<img width="825" alt="Screen Shot 2020-10-01 at 10 53 42 PM" src="https://user-images.githubusercontent.com/192614/94892253-0d6fa680-0439-11eb-8750-681c42cb3cee.png">
