### PR TITLE
Add more explanation about what it means to be a distinguished contributor

### DIFF
--- a/_includes/distinguished.html
+++ b/_includes/distinguished.html
@@ -3,10 +3,15 @@
     <div class="row">
         <h3 class="col-sm-12 section-header">Distinguished Contributors</h3>
         <p class="col-sm-12">
-        After the <a href="https://github.com/jupyter/governance/pull/84">Jupyter
-        Distinguished Contributor body was unanimously approved</a> in September
-        2020, we held a special election to begin addressing our backlog of
-        gratitude to members of our community in recognition of their efforts.
+          Project Jupyter <a href="https://jupyter.org/governance/distinguished_contributors.html">Distinguished
+          Contributors</a> are recognized for their substantial contributions
+          to Jupyter itself in both quality and quantity over at least two
+          years. Contributions may include code, code review, infrastructure
+          work, mailing list and chat participation, community help/building,
+          education and outreach, fundraising, branding, marketing, inclusion
+          and diversity, UX design and research, etc. Up to 10 new
+          Distinguished Contributors are selected each year by the cumulative
+          body of Distinguished Contributors.
         </p>
     </div>
     <div class="row">


### PR DESCRIPTION
This adds a bit more text to the listing of distinguished contributors quoting what the recognition means from the governance docs.