### PR TITLE
Add link to Jupyter 2021 survey

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -60,7 +60,7 @@
     <div class="row">
         <div class="col-md-12">
             <div class="survey col-md-8 col-md-offset-2">
-            <p class="survey">Help the Jupyter Community by participating in the <a href="https://www.surveymonkey.com/r/QMYH5CM" target="_blank" >2021 Survey</a></p>
+            <p class="survey">Help the Jupyter Community by participating in the <a href="https://www.surveymonkey.com/r/QMYH5CM" target="_blank">2021 Survey</a></p>
             </div>
          </div>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -60,7 +60,7 @@
     <div class="row">
         <div class="col-md-12">
             <div class="survey col-md-8 col-md-offset-2">
-            <p class="survey">Help the Jupyter Community by participating in the <a href="https://t.co/ILminrlq77?amp=1">2021 Survey</a></p>
+            <p class="survey">Help the Jupyter Community by participating in the <a href="https://www.surveymonkey.com/r/QMYH5CM" target="_blank" >2021 Survey</a></p>
             </div>
          </div>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -55,3 +55,13 @@
         <!-- /.container -->
     </div>
 </nav>
+
+<div class="container">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="survey col-md-8 col-md-offset-2">
+            <p class="survey">Help the Jupyter Community by participating in the <a href="https://t.co/ILminrlq77?amp=1">2021 Survey</a></p>
+            </div>
+         </div>
+    </div>
+</div>

--- a/css/about.css
+++ b/css/about.css
@@ -76,3 +76,21 @@ div.page_content img.council-member-photo {
     transition: all 0.2s ease-in-out;
     width: 160px;
 }
+
+/* Styling for the call-to-Survey box*/
+.survey {
+    display: inline-block;
+    width: 100%;
+    margin: 10px;
+    background-color: #F27624;
+    color: #ffff;
+    text-align: center;
+}
+
+.survey.p {
+  padding-top: 10px;
+}
+
+.survey.a:active {
+  color: #ffff;
+}

--- a/index.html
+++ b/index.html
@@ -18,8 +18,6 @@ div#countdown {
 </style>
 
 
-
-
 <section>
     <div class="jumbotron">
         <div class="row">


### PR DESCRIPTION
We are doing a community survey for Jupyter/JupyterLab as discussed in https://github.com/jupyterlab/team-compass/pull/107. To bring more visibility, we would like to leave the calling for participants on the Jupyter website for a few weeks. 

![image](https://user-images.githubusercontent.com/382917/103663735-47fc4a00-4f26-11eb-835d-a408f327f3b7.png)

Please feel free to provide design feedback in the form of additions to my pr.

