### PR TITLE
Fix the problem with widgets content tab mis-alignement

### DIFF
--- a/css/gallery.css
+++ b/css/gallery.css
@@ -20,6 +20,15 @@
     line-height: 32px;
 }
 
+.tabs-left {
+  display: flex;
+}
+
+.tab-content {
+  lex-shrink: 0;
+  flex-grow: 1;
+}
+
 .tabs-left > .nav-tabs {
   border-bottom: 0;
 }


### PR DESCRIPTION
Fixes #364 problem 2 (problem 1 was already fixed).

`display: flex` is magic, we need more of it.