### PR TITLE
Add new events page and top-level heading to highlight many Jupyter events

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -4,6 +4,8 @@ head:
     - About Us
     - title: Community
       url: /community
+    - title: Events
+      url: /events
     - Documentation
     - title: NBViewer
       url: https://nbviewer.jupyter.org

--- a/community.md
+++ b/community.md
@@ -20,16 +20,10 @@ This contains information about the different projects in the Jupyter ecosystem,
 the tools and skills that are useful for each project, and other ways that you
 can become a part of the Jupyter community.
 
-### JupyterDays, JupyterCon, and other events
+### Events
 
-Many members of the Jupyter community host events to connect others that use
-Jupyter and other tools in the open data analytics stack. For example,
-[JupyterCon](https://jupytercon.com/) is an annual conference that brings together many
-different groups represented in the Jupyter Community. **Jupyter Days**
-are smaller, locally-organized events for learning and connecting with one
-another. For example, [here's a post announcing Jupyter Days in Atlanta](https://blog.jupyter.org/announcing-jupyter-day-atlanta-spring-2018-d68ebee2c6cb).
-If you'd like to organize a Jupyter Days event in your community, please
-reach out!
+Many members of the Jupyter community host and attend events to connect others that use
+Jupyter and other tools in the open data analytics stack, such as JupyterCon, Jupyter Community Workshops, JupyterDays, and other events. See the [Project Jupyter Events](/events) for more details.
 
 ## Explore our projects
 

--- a/events.md
+++ b/events.md
@@ -9,11 +9,11 @@ Project Jupyter events provide a forum for community members to come together in
 
 ## JupyterCon
 
-Global JupyterCon conferences provide opportunities for the entire Jupyter community to come together to learn and share.
+Global JupyterCon conferences provide opportunities for the Jupyter community to come together to learn and share.
 
 * [JupyterCon 2017](https://conferences.oreilly.com/jupyter/jup-ny-2017.html) ([videos](https://www.youtube.com/playlist?list=PL055Epbe6d5aP6Ru42r7hk68GTSaclYgi))
 * [JupyterCon 2018](https://conferences.oreilly.com/jupyter/jup-ny.html) ([videos](https://www.youtube.com/playlist?list=PL055Epbe6d5b572IRmYAHkUgcq3y6K3Ae))
-* [JupyterCon 2020](https://jupytercon.com/) ([videos](https://www.youtube.com/c/JupyterCon/videos))
+* [JupyterCon 2020 (virtual)](https://jupytercon.com/) ([videos](https://www.youtube.com/c/JupyterCon/videos))
 
 
 ## Jupyter Community Workshops

--- a/events.md
+++ b/events.md
@@ -53,6 +53,7 @@ Individual workshops:
 
 Due to the COVID-19 pandemic, workshops were put on hold during 2020. Stay tuned for more details about workshops funded in round 3.
 
+<!--
 ## Jupyter Subproject Sprints
 
 A number of Jupyter subprojects have hosted in-person sprints open to the public to push forward on development priorities.
@@ -61,10 +62,14 @@ A number of Jupyter subprojects have hosted in-person sprints open to the public
 
 A number of smaller, locally-organized single-day Jupyter Days events have been hosted. For example, [here's a post announcing Jupyter Days in Atlanta](https://blog.jupyter.org/announcing-jupyter-day-atlanta-spring-2018-d68ebee2c6cb)
 
+-->
+
 ## Jupyter Community Calls
 
 [Jupyter Community Calls](https://jupyter.readthedocs.io/en/latest/community/content-community.html#jupyter-wide-meetings) provide a regular virtual forum for community-wide discussion and sharing.
 
+<!--
 ## Calendar
 
 Jupyter Community meetings are listed in the [Project Jupyter Calendar](https://jupyter.readthedocs.io/en/latest/community/content-community.html#jupyter-community-meetings)
+-->

--- a/events.md
+++ b/events.md
@@ -1,0 +1,70 @@
+---
+layout: page_md
+title: Stay Connected
+tagline: Project Jupyter sponsors a number of events for individuals interested in using and contributing to the project.
+permalink: /events
+---
+
+Project Jupyter events provide a forum for community members to come together in person or virtually to share and learn from each other.
+
+## JupyterCon
+
+Global JupyterCon conferences provide opportunities for the entire Jupyter community to come together to learn and share.
+
+* [JupyterCon 2017](https://conferences.oreilly.com/jupyter/jup-ny-2017.html) ([videos](https://www.youtube.com/playlist?list=PL055Epbe6d5aP6Ru42r7hk68GTSaclYgi))
+* [JupyterCon 2018](https://conferences.oreilly.com/jupyter/jup-ny.html) ([videos](https://www.youtube.com/playlist?list=PL055Epbe6d5b572IRmYAHkUgcq3y6K3Ae))
+* [JupyterCon 2020](https://jupytercon.com/) ([videos](https://www.youtube.com/c/JupyterCon/videos))
+
+
+## Jupyter Community Workshops
+
+[Jupyter Community Workshops](https://blog.jupyter.org/jupyter-community-workshops-cbd34ac82549) bring together small groups (approximately 12 to 24 people) of Jupyter community members and core contributors for high-impact strategic work and community engagement on focused topics.
+
+Much of Jupyter’s work is accomplished through remote, online collaboration; yet, over the years, we have found deep value in focused in-person work over a few days. These in-person events are particularly useful for tackling challenging development and design projects, growing the community of contributors, and strengthening collaborations.
+
+### Round 1: 2018
+
+- [Round 1: Call for Proposals](https://blog.jupyter.org/jupyter-community-workshops-cbd34ac82549)
+
+Individual workshops:
+- [Jupyter Widgets workshop](https://blog.jupyter.org/jupyter-community-workshops-cbd34ac82549)
+- [Jupyter Hackathon in Hawaii](https://blog.jupyter.org/jupyter-hackathon-series-in-hawaii-97b3d1fbce68)
+- [Teaching and Learning with Jupyter](https://blog.jupyter.org/teaching-and-learning-with-jupyter-c1d965f7b93a)
+
+
+### Round 2: 2019
+
+- [Round 2: Call for Proposals](https://blog.jupyter.org/jupyter-community-workshops-call-for-proposals-26a8417e5b6a)
+- [Round 2: Announcement of Workshops](https://blog.jupyter.org/jupyter-community-workshops-a7f1dca1735e)
+- [Round 2: 2019 Year in Review](https://blog.jupyter.org/jupyter-community-workshops-2019-year-in-review-8876336924e4)
+
+Individual workshops:
+- [Jupyter Server Design and Roadmap Workshop](https://blog.jupyter.org/jupyter-community-workshop-jupyter-server-design-and-roadmap-workshop-6e6760cc5098): (Luciano Resende)
+- [Building upon the Jupyter Kernel Protocol](https://blog.jupyter.org/field-report-on-the-kernel-community-workshop-a4ad73a1a718) (Sylvain Corlay)
+- [Jupyter nbgrader Hackathon/Code Sprint](https://blog.jupyter.org/https-blog-jupyter-org-university-of-edinburgh-jupyter-community-nbgrader-hackathon-2eff14df298a): (James Slack)
+- [Intro to Python for Kids, Parents & Teachers Series](https://datasciencecornwall.blogspot.com/2019/06/python-data-science-for-kids-taster.html): (Tariq Rashad)
+- [Dashboarding in the Jupyter Ecosystem](https://blog.jupyter.org/report-on-the-jupyter-community-workshop-on-dashboarding-14f8ad9f3c0): (Pascal Bugnion, Sylvain Corlay)
+- [Jupyter for Scientific User Facilities and High-Performance Computing](https://blog.jupyter.org/jupyter-for-science-user-facilities-and-high-performance-computing-de178106872): (Rollin Thomas)
+- [South America Jupyter Community Workshop](https://blog.jupyter.org/south-america-jupyter-community-workshop-4edc51c7a6ce): (Damian Avila)
+
+### Round 3: 2020-2022
+
+- [Round 3: Call for Proposals](https://blog.jupyter.org/jupyter-community-workshops-call-for-proposals-for-jan-aug-2020-710f687e30f4)
+
+Due to the COVID-19 pandemic, workshops were put on hold during 2020. Stay tuned for more details about workshops funded in round 3.
+
+## Jupyter Subproject Sprints
+
+A number of Jupyter subprojects have hosted in-person sprints open to the public to push forward on development priorities.
+
+## JupyterDays
+
+A number of smaller, locally-organized single-day Jupyter Days events have been hosted. For example, [here's a post announcing Jupyter Days in Atlanta](https://blog.jupyter.org/announcing-jupyter-day-atlanta-spring-2018-d68ebee2c6cb)
+
+## Jupyter Community Calls
+
+[Jupyter Community Calls](https://jupyter.readthedocs.io/en/latest/community/content-community.html#jupyter-wide-meetings) provide a regular virtual forum for community-wide discussion and sharing.
+
+## Calendar
+
+Jupyter Community meetings are listed in the [Project Jupyter Calendar](https://jupyter.readthedocs.io/en/latest/community/content-community.html#jupyter-community-meetings)


### PR DESCRIPTION
This page adds a new `juptyer.org/events` page that collects information about Jupyter Events in the past and provides a place to advertise upcoming events in the future.

The language is just a first draft, so I have set the PR as a draft PR for now.

[Preview here](https://deploy-preview-412--dazzling-gates-2d8e39.netlify.app/events)