### PR TITLE
Establish a /security page

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -15,3 +15,5 @@ head:
     - title: Blog
       url: https://blog.jupyter.org
       newpage: true
+    - title: Security
+      url: /security

--- a/community.md
+++ b/community.md
@@ -57,11 +57,4 @@ a way that makes the community thrive.
 Below is a short list of gitter channels, email listservs, and github repositories
 where you can get involved. **We always welcome participation in the Jupyter community**.
 
-## Report vulnerabilities
-
-If you believe you've found a security vulnerability in a Jupyter project,
-please report it to [security@ipython.org](mailto:security@ipython.org).
-If you prefer to encrypt your security reports,
-you can use [this PGP public key](assets/ipython_security.asc).
-
 {% include community_lists.html %}

--- a/security.md
+++ b/security.md
@@ -1,0 +1,32 @@
+---
+layout: page_md
+title: Security
+tagline: Project Jupyter is committed to reducing the risk of using, deploying, operating, or developing Jupyter software.
+permalink: /security
+---
+
+## Report vulnerabilities
+
+If you believe you've found a security vulnerability in a Jupyter project,
+please report it to [security@ipython.org](mailto:security@ipython.org).
+If you prefer to encrypt your security reports,
+you can use [this PGP public key](assets/ipython_security.asc).
+
+## Vulnerability information
+
+Known vulnerabilities are tracked using the [CVE vendor ID 15653 for Jupyter](https://www.cvedetails.com/vulnerability-list/vendor_id-15653/Jupyter.html).
+
+## Security documentation
+
+Several Jupyter projects maintain security-related documentation regarding usage or deployment of
+Jupyter software.
+
+- [jupyter-server](https://jupyter-server.readthedocs.io/en/latest/operators/security.html)
+- [jupyterhub](https://jupyterhub.readthedocs.io/en/stable/reference/websecurity.html)
+
+## Jupyter Security Subproject
+
+The Jupyter Security Subproject is working to identify and coordinate
+the security efforts throughout the Jupyter community. The
+[Jupyter Security](https://github.com/jupyter/security) GitHub repo
+has information how to participate and contribute.


### PR DESCRIPTION
This is a minimal page to begin collecting information around security. It moves the vulnerability reporting information from the community page to security. There's an [issue for discussing this page generally over on the security repo](https://github.com/jupyter/security/issues/1).