### PR TITLE
Update the Binder link to the classic notebook

### DIFF
--- a/_data/try.yml
+++ b/_data/try.yml
@@ -3,7 +3,7 @@
     A tutorial introducing basic features of Jupyter notebooks
     and the IPython kernel using the classic Jupyter Notebook interface.
   logo: python.svg
-  url: https://mybinder.org/v2/gh/ipython/ipython-in-depth/master?filepath=binder/Index.ipynb
+  url: https://mybinder.org/v2/gh/ipython/ipython-in-depth/master?urlpath=tree/binder/Index.ipynb
 
 - title: Try JupyterLab
   description: |


### PR DESCRIPTION
Now that mybinder.org has switched to JupyterLab as the default UI: https://discourse.jupyter.org/t/mybinder-org-using-jupyterlab-by-default/10715

We can update the link to explicitly redirect to the classic notebook interface.