### PR TITLE
A clearer tagline on the about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,7 +1,7 @@
 ---
 layout: page_md
 title: "About Us"
-tagline: Some information about the Jupyter Project and Community
+tagline: Project Jupyter’s origins and governance
 permalink: /about
 distinguished_2020:
   - name: Jeremy Tuloup


### PR DESCRIPTION
The use of the word "community" muddles the intentions of this page in comparison to the Community page in the nav.