### PR TITLE
Tightned up the hed and tagline of the Community page

### DIFF
--- a/community.md
+++ b/community.md
@@ -1,7 +1,7 @@
 ---
 layout: page_md
-title: Stay Connected
-tagline: Project Jupyter offers a number of communication channels available to individuals interested in using and contributing to the project.
+title: Community
+tagline: How to get involved with Project Jupyter
 permalink: /community
 ---
 


### PR DESCRIPTION
Current tagline is running a little long, and I think the page would be better off with a hed that matches the nav name.