### PR TITLE
Best practices fixes for Lighthouse

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
                     <li><a href="{{site.baseurl}}/index.html">Home</a></li>
                     {%- for nav in site.data.nav.head %}
                       {%- if nav.url %}
-                               <li><a href="{{site.baseurl}}{{nav.url}}">{{nav.title}}</a></li>
+                               <li><a href="{{site.baseurl}}{{nav.url}}" target="_blank" rel="noopener noreferrer">{{nav.title}}</a></li>
                       {%- else %}
                         {%- for target_page in site.pages %}
                            {%- if nav contains target_page.title %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
                     <li><a href="{{site.baseurl}}/index.html">Home</a></li>
                     {%- for nav in site.data.nav.head %}
                       {%- if nav.url %}
-                               <li><a href="{{site.baseurl}}{{nav.url}}" target="_blank">{{nav.title}}</a></li>
+                               <li><a href="{{site.baseurl}}{{nav.url}}">{{nav.title}}</a></li>
                       {%- else %}
                         {%- for target_page in site.pages %}
                            {%- if nav contains target_page.title %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -27,7 +27,7 @@
                       {%- if nav.url %}
                                <li>
                                  {%- if nav.newpage %}
-                                 <a href="{{site.baseurl}}{{nav.url}}" class="tab" target="_blank">{{nav.title}}</a>
+                                 <a href="{{site.baseurl}}{{nav.url}}" class="tab">{{nav.title}}</a>
                                  {%- else %}
                                  <a href="{{site.baseurl}}{{nav.url}}" class="tab">{{nav.title}}</a>
                                  {%- endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -27,7 +27,7 @@
                       {%- if nav.url %}
                                <li>
                                  {%- if nav.newpage %}
-                                 <a href="{{site.baseurl}}{{nav.url}}" class="tab">{{nav.title}}</a>
+                                 <a href="{{site.baseurl}}{{nav.url}}" class="tab" target="_blank" rel="noopener noreferrer">{{nav.title}}</a>
                                  {%- else %}
                                  <a href="{{site.baseurl}}{{nav.url}}" class="tab">{{nav.title}}</a>
                                  {%- endif %}


### PR DESCRIPTION
Lighthouse's Best Practices suggestion recommends against this target _blank links because they can lead to vulnerabilities in rare circumstances.