### PR TITLE
Add Jupyter Server documentation link to Foundations

### DIFF
--- a/_data/documentation.yml
+++ b/_data/documentation.yml
@@ -45,4 +45,5 @@ Deployment:
 Foundations:
   Jupyter Client: https://jupyter-client.readthedocs.io/en/latest/
   Jupyter Core: https://jupyter-core.readthedocs.io/en/latest/
+  Jupyter Server: https://jupyter-server.readthedocs.io/
   Jupyter Alabaster Theme: https://jupyter-alabaster-theme.readthedocs.io/en/latest/


### PR DESCRIPTION
Noticed it's missing when reviewing https://github.com/jupyter/jupyter.github.io/pull/430