### PR TITLE
Cut NBViewer from the nav

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -7,9 +7,6 @@ head:
     - title: Events
       url: /events
     - Documentation
-    - title: NBViewer
-      url: https://nbviewer.jupyter.org
-      newpage: true
     - JupyterHub
     - Widgets
     - title: Blog


### PR DESCRIPTION
Per the discussion in #433, the NBViewer nav link is out of keeping with the other links in the list.

1) It's a subproject, not metadata about Project Jupyter
2) It's an undefined piece of jargon, which we shouldn't expect newbies to grok

For these reasons, I propose cutting the link from the nav. It will make the list clearer and shorter. If greater promotion for NBView is sought, I would argue for adding another element to the homepage stack, in the style of JupyterLab and Jupyter Notebook.