### PR TITLE
Cut JupyterHub from the nav

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -10,7 +10,6 @@ head:
     - title: NBViewer
       url: https://nbviewer.jupyter.org
       newpage: true
-    - JupyterHub
     - Widgets
     - title: Blog
       url: https://blog.jupyter.org

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@ div#countdown {
                 </div>
             </div>
             <div class="col-md-12" style="text-align: center; margin-top: 24px;">
-                <a class="orange-button" href="https://jupyterhub.readthedocs.io/en/stable/">Learn more about JupyterHub</a>
+                <a class="orange-button" href="/hub">Learn more about JupyterHub</a>
             </div>
             </div>
         </div>


### PR DESCRIPTION
Per the discussion in #433, I propose removing the JupyterHub link from the nav. Hub is the only project featured on the homepage that also appears in the nav. This leads to confusion about what is in the nav and why. It also crowds that part of the page with yet another link.

For those reasons, I suggest we cut the link. For consistency's sake, I've replace the outbound link to JupyterHub's documentation now on the homepage with a link to the page on this site. 