### PR TITLE
Revert back to indefinite article for JupyterLab's "next-generation" status

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ div#countdown {
         <div class="row">
             <div class="col-md-12">
                 <div class="col-md-8 col-md-offset-2">
-                <h4 class="jumbotron-text">Project Jupyter develops open-source software, open standards
+                <h4 class="jumbotron-text">Project Jupyter develops open-source software, open standards,
                     and services for interactive computing across dozens of programming languages.</h4>
                 </div>
              </div>
@@ -59,7 +59,7 @@ div#countdown {
                     </div>
                     <div class="col-md-6 nb-highlight-text">
                         <h3>JupyterLab: A Next-Generation Notebook Interface</h3>
-                        <h4 class="nb-desc">JupyterLab is a web-based interactive development environment for notebooks, code and data. Its flexible interface allows users to configure and arrange workflows in data science, scientific computing, computational journalism and machine learning. A modular design allows for extensions that expand and enrich functionality.</h4>
+                        <h4 class="nb-desc">JupyterLab is a web-based interactive development environment for notebooks, code, and data. Its flexible interface allows users to configure and arrange workflows in data science, scientific computing, computational journalism, and machine learning. A modular design allows for extensions that expand and enrich functionality.</h4>
                         <div class="button-container">
                             <a class="orange-button" href="try">Try it in your browser</a>
                             <a class="orange-button install-button" href="install.html">Install JupyterLab</a>
@@ -81,7 +81,7 @@ div#countdown {
                     <div class="col-md-6 nb-highlight-text">
                         <h3>Jupyter Notebook: The Classic Notebook Interface</h3>
                         <h4 class="nb-desc">The Jupyter Notebook is a web application for creating and sharing
-                            documents that contain code, visualizations and text. It can be used for data science, statistical modeling, machine learning and much more.</h4>
+                            documents that contain code, visualizations, and text. It can be used for data science, statistical modeling, machine learning, and much more.</h4>
                         <div class="button-container">
                             <a class="orange-button" href="try">Try it in your browser</a>
                             <a class="orange-button install-button" href="install.html">Install the Notebook</a>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ div#countdown {
                         <img class="img-responsive" src="assets/labpreview.png" id="portal" alt="examples of jupyterlab workspaces in single document and multiple document workspaces"/>
                     </div>
                     <div class="col-md-6 nb-highlight-text">
-                        <h3>JupyterLab: The Next-Generation Notebook Interface</h3>
+                        <h3>JupyterLab: A Next-Generation Notebook Interface</h3>
                         <h4 class="nb-desc">JupyterLab is a web-based interactive development environment for notebooks, code and data. Its flexible interface allows users to configure and arrange workflows in data science, scientific computing, computational journalism and machine learning. A modular design allows for extensions that expand and enrich functionality.</h4>
                         <div class="button-container">
                             <a class="orange-button" href="try">Try it in your browser</a>


### PR DESCRIPTION
Since adding the announcement of JupyterLab to the jupyter.org front page (see #340 ), we've been deliberate in the past about using  an indefinite article when referring to JupyterLab's status a next-generation interface.

Some of the reasons include the fact that JupyterLab is not the only "next-generation notebook interface". For example, [nteract](https://github.com/nteract/nteract) has been around as long as JupyterLab, and a bunch of editors and IDEs have impressive Jupyter intergrations and plugins ([Emacs IPython Notebook (EIN)](https://github.com/millejoh/emacs-ipython-notebook), [Spyder](https://github.com/spyder-ide/spyder-notebook), [Hydrogen for Atom](https://github.com/nteract/hydrogen), [VS Code](https://code.visualstudio.com/docs/datascience/jupyter-notebooks), [IntelliJ IDEA](https://www.jetbrains.com/help/idea/jupyter-notebook-support.html), [PyCharm](https://www.jetbrains.com/help/pycharm/configuring-jupyter-notebook.html) ).  Furthermore, JupyterLab components can and have been re-used to create, for lack of a better term "non-Lab-like" interfaces, so let a thousand interfaces bloom! :seedling: :rose: :rosette: :tulip: :white_flower:

I understand that there's a natural tendency to refer to it as "the" next-generation notebook interface, give that Jupyter Notebook is referred to as "The Classic Notebook Interface", but the definite article is appropriate for classic notebook, as it was canonical Jupyter, whereas we want to support the notion that many interfaces can be built for the Jupyter protocols and file specs.

For a while, this tagline was "Jupyter's next-generation notebook interface", so I'm amenable to reverting back to that, or also changing the tagline to something like "an extensible environment for interactive computing".