### PR TITLE
Rename Community tab as Get Involved

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -2,7 +2,7 @@ head:
     - title: Install
       url: /install
     - About Us
-    - title: Community
+    - title: Get Involved
       url: /community
     - title: Events
       url: /events

--- a/community.md
+++ b/community.md
@@ -1,7 +1,7 @@
 ---
 layout: page_md
-title: Community
-tagline: How to get involved with Project Jupyter
+title: Get Involved
+tagline: How to join the Project Jupyter community
 permalink: /community
 ---
 


### PR DESCRIPTION
The current name is a bit vague. It also doesn't do much to distinguish itself from its nav neighbor Events. This tweak will get users a clearer indication of what's on the subpage and will, I'd wager, act as a stronger enticement to homepage visitors.