### PR TITLE
Rename Blog nav item as News

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -11,7 +11,7 @@ head:
       url: https://nbviewer.jupyter.org
       newpage: true
     - Widgets
-    - title: Blog
+    - title: News
       url: https://blog.jupyter.org
       newpage: true
     - title: Security


### PR DESCRIPTION
I'm an Old Internet guy. I love the word blog. I've been paid to write them. That said, it's a techie term and a little dated. A more accurate description of what readers can expect if they click this list is news about Project Jupyter. So I propose that the nav link be renamed as News.

Other large open-source projects already do this, like Django, which has a nav link called NEWS that leads to https://www.djangoproject.com/weblog/