### PR TITLE
Fix sitemap with config change

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,3 +19,4 @@ include: [".well-known"]
 
 plugins:
   - jekyll-redirect-from
+  - jekyll-sitemap


### PR DESCRIPTION
Despite the plugin being included with the Gemfile, the sitemap is not building. This appears to be due to the fact that the plugin is not listed in Jekyll's config file. [The authors](https://github.com/jekyll/jekyll-sitemap) warn of this problem.

![Screenshot from 2021-12-04 13-42-33](https://user-images.githubusercontent.com/9993/144725472-ca5890d4-6eba-4113-9542-ee4aef4edda7.png)

I've patched that here. It should fix #460 