### PR TITLE
Cut old IE edge meta tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,6 @@
 <head>
 
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta itemprop="description" name="description" content="{% if page.tagline %}{{ page.tagline }}{% else %}{{ site.description }}{% endif %}" />
 


### PR DESCRIPTION
I think we're safe to let this one go. See [this post](https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do) on StackOverflow for more information.