### PR TITLE
Add jupyter-lsp organization to repo lists on community page

### DIFF
--- a/community.md
+++ b/community.md
@@ -38,6 +38,7 @@ in these organizations:
 - [jupyter-widgets](https://github.com/jupyter-widgets)
 - [jupyter-server](https://github.com/jupyter-server)
 - [jupyter-xeus](https://github.com/jupyter-xeus)
+- [jupyter-lsp](https://github.com/jupyter-lsp)
 - [voila-dashboards](https://github.com/voila-dashboards)
 - [binder-examples](https://github.com/binder-examples)
 - [jupyter-resources](https://github.com/jupyter-resources)


### PR DESCRIPTION
Adds jupyter-lsp organization to repo lists on community page.

Before:

![Screenshot from 2021-12-19 12-48-49](https://user-images.githubusercontent.com/5832902/146675424-dfb81cff-ed5b-4ed3-b6bd-fe32e261f5a6.png)

After:

TBD