### PR TITLE
Mention other gitter channels

### DIFF
--- a/_includes/community_lists.html
+++ b/_includes/community_lists.html
@@ -79,7 +79,7 @@
                         </div>
                         <div class="col-md-8 resource-text">
                             <h3 class="resource-name">Jupyter Gitter Chatroom</h3>
-                            <p class="resource-desc">A real-time chatroom, for general development related discussions.</p>
+                            <p class="resource-desc">A real-time chatroom, for general development related discussions. Many Jupyter subprojects have their own Gitter channels.</p>
                         </div>
                         <div class="col-md-2 resource-button">
                             <a href="https://gitter.im/jupyter/jupyter">View</a>


### PR DESCRIPTION
Due to wide scope of Jupyter, the https://gitter.im/jupyter/jupyter channel is often noisy with redirection to subproject-specific channels (or sometimes question stay unanswered because they are not seen by people who could have answered but are not catching up with the main channel). By including a short mention that other channels exist we might help users reach the appropriate channel quicker. I originally thought about enumerating all major channels (like jupyterlab, jupyterhub, binder, etc) but there is just not enough space with the current design.