### PR TITLE
Rename Documentation page as Projects

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -6,7 +6,8 @@ head:
       url: /community
     - title: Events
       url: /events
-    - Documentation
+    - title: Projects
+      url: /projects
     - Widgets
     - title: News
       url: https://blog.jupyter.org

--- a/documentation.md
+++ b/documentation.md
@@ -1,8 +1,0 @@
----
-layout: page_md
-title: Documentation
-tagline: A comprehensive list of Jupyter projects, subprojects and repositories
-permalink: /documentation
----
-
-{% include documentation.html %}

--- a/projects.md
+++ b/projects.md
@@ -1,3 +1,10 @@
+---
+layout: page_md
+title: Projects
+tagline: A comprehensive list of Jupyter projects, subprojects and repositories
+permalink: /projects
+---
+
 <section>
     <div class="top-section-border">
         <div class="container">


### PR DESCRIPTION
Looked at with fresh eyes, the current "Documentation" page isn't really documentation. It's a list of Project Jupyter affiliated projects, where you can find documentation. Therefore, I propose this change.