### PR TITLE
Simplify footer by removing duplicate links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,32 +1,17 @@
 <footer>
-    <div class="footer" role="navigation">
-        <div class="container">
-            <div class="navbar-text">
-                <ul class="footer-text">
-                    <li><a href="{{site.baseurl}}/index.html">Home</a></li>
-                    {%- for nav in site.data.nav.head %}
-                      {%- if nav.url %}
-                               <li><a href="{{site.baseurl}}{{nav.url}}" target="_blank" rel="noopener noreferrer">{{nav.title}}</a></li>
-                      {%- else %}
-                        {%- for target_page in site.pages %}
-                           {%- if nav contains target_page.title %}
-                               <li><a href="{{site.baseurl}}{{target_page.url}}">{{target_page.title}}</a></li>
-                           {%- endif %}
-                           {%- endfor %}
-                      {%- endif %}
-                    {%- endfor %}
-                    <!--{{ site.time}}-->
-                </ul>
-                <p>Copyright © {{site.time | date: '%Y' }}  Project Jupyter –
-                Last updated {{site.time | date: "%a, %b %d, %Y" }}</p>
-                <p>The Jupyter Trademark is registered with the U.S. Patent &amp; Trademark Office.</p>
-            </div>
-            <div class="follow">
-                <a href="https://github.com/jupyter" class="button github-button" aria-label="Follow @jupyter on GitHub"><svg version="1.1" width="14" height="14" viewBox="0 0 16 16" class="octicon octicon-mark-github" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg> <span>Follow @jupyter</span></a>
-                <br><a href="https://twitter.com/intent/follow?screen_name=ProjectJupyter" class="twitter-follow-button" data-show-count="false">Follow @ProjectJupyter on Twitter</a>
-            </div>
+<div class="footer" role="navigation">
+    <div class="container">
+        <div class="navbar-text">
+            <p>Copyright © {{site.time | date: '%Y' }}  Project Jupyter –
+            Last updated {{site.time | date: "%a, %b %d, %Y" }}</p>
+            <p>The Jupyter Trademark is registered with the U.S. Patent &amp; Trademark Office.</p>
+        </div>
+        <div class="follow">
+            <a href="https://github.com/jupyter" class="button github-button" aria-label="Follow @jupyter on GitHub"><svg version="1.1" width="14" height="14" viewBox="0 0 16 16" class="octicon octicon-mark-github" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg> <span>Follow @jupyter</span></a>
+            <br><a href="https://twitter.com/intent/follow?screen_name=ProjectJupyter" class="twitter-follow-button" data-show-count="false">Follow @ProjectJupyter on Twitter</a>
         </div>
     </div>
+</div>
 </footer>
 
 <!-- jQuery -->


### PR DESCRIPTION
The links in the footer are currently too small to pass accessibility tests. And with those same links in the navigation bar at the top of the page, they are unnecessary. One way to fix the bug: Delete these links. They aren't needed. So let's strip it down. We can always revisit the footer in the future.