### PR TITLE
Slight trim to jumbotron text for concision

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ cfp: true
 permalink: /
 
 jumbotron:
-  text: Project Jupyter develops open-source software, open standards, and services for interactive computing across dozens of programming languages.
+  text: Open-source software, open standards, and services for interactive computing across dozens of programming languages
   images:
     - class: fade-in one
       alt: circle of programming language icons


### PR DESCRIPTION
Every little cut strengthens the page, IMHO. Especially at the top. Here's another small suggestion.

Before:
![Screenshot from 2021-12-24 04-30-43](https://user-images.githubusercontent.com/9993/147352824-b74fd9c8-4e0d-4287-8073-163ecf6d84d9.png)

After:
![Screenshot from 2021-12-24 04-33-32](https://user-images.githubusercontent.com/9993/147352918-61467078-3529-43ad-bdb3-c296a5a9d541.png)
