### PR TITLE
ENH: Lazy load images on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,11 +238,12 @@ in_use:
                     <span>
                         <img class="img-responsive {{ img.class }}"
                              src="{{ img.src }}"
-                             alt="{{ img.alt }}">
+                             alt="{{ img.alt }}"
+                             loading="eager" />
                     </span>
                 </div>
                 {% endfor %}
-                <img class="img-responsive" src="assets/white-background.svg" alt="white background">
+                <img class="img-responsive" src="assets/white-background.svg" alt="white background" loading="eager">
             </div>
         </div>
     </div>
@@ -267,7 +268,8 @@ in_use:
                             <img src="{{ page.jupyterlab.image.src }}.jpg"
                                  alt="{{ page.jupyterlab.image.alt }}"
                                  class="img-responsive"
-                                 id="portal" />
+                                 id="portal"
+                                 loading="lazy" />
                         </picture>
                     </div>
                     <div class="col-md-6 nb-highlight-text">
@@ -296,7 +298,8 @@ in_use:
                             <img src="{{ page.notebook.image.src }}.jpg"
                                  alt="{{ page.notebook.image.alt }}"
                                  class="img-responsive"
-                                 id="portal" />
+                                 id="portal"
+                                 loading="lazy" />
                         </picture>
                     </div>
                     <div class="col-md-6 nb-highlight-text">
@@ -317,7 +320,11 @@ in_use:
                 <div class="row">
                     {% for feat in page.notebook.features %}
                     <div class="col-md-3 notebook-feature">
-                        <img class="img-responsive" src="{{ feat.image.src }}" id="feature" alt="{{ feat.image.alt }}">
+                        <img class="img-responsive"
+                             src="{{ feat.image.src }}"
+                             id="feature"
+                             alt="{{ feat.image.alt }}"
+                             loading="lazy" />
                         <h4>{{ feat.headline }}</h4>
                         <p>{{ feat.description }}</p>
                     </div>
@@ -334,7 +341,7 @@ in_use:
             <div>
                 <div class="hublogo col-md-offset-4 col-md-4 col-md-offset-4">
                     <img src="{{ page.jupyterhub.image.src }}" class="img-responsive" style="margin:0 auto;" id="hublogo"
-                         alt="{{ page.jupyterhub.image.alt }}">
+                         alt="{{ page.jupyterhub.image.alt }}" loading="lazy" />
                 </div>
                 <div class="col-md-offset-3 col-md-6 col-md-offset-3" style="margin-bottom:-36px">
                     <p style="padding-top:24px; text-align: center">{{ page.jupyterhub.description }}</p>
@@ -343,7 +350,7 @@ in_use:
             <div class="hubfeatures col-md-12">
                 {% for feat in page.jupyterhub.features %}
                 <div class="{{ feat.class }} hubfeature col-md-3">
-                    <img src="{{ feat.image.src }}" class="img-responsive" alt="{{ feat.image.alt }}">
+                    <img src="{{ feat.image.src }}" class="img-responsive" alt="{{ feat.image.alt }}" loading="lazy">
                     <h4>{{ feat.headline }}</h4>
                     <p>{{ feat.description }}</p>
                 </div>
@@ -367,7 +374,8 @@ in_use:
                             <img src="{{ page.voila.image.src }}.jpg"
                                  alt="{{ page.voila.image.alt }}"
                                  class="img-responsive"
-                                 id="portal" />
+                                 id="portal" 
+                                 loading="lazy" />
                         </picture>
                     </div>
                     <div class="col-md-6 nb-highlight-text">
@@ -396,7 +404,7 @@ in_use:
                 {% for li in page.in_use.companies %}
                 <li class="col">
                     <a href="{{ li.href }}">
-                        <img src="{{ li.src }}" class="greydout" alt="{{ li.alt }}">
+                        <img src="{{ li.src }}" class="greydout" alt="{{ li.alt }}" loading="lazy">
                     </a>
                 </li>
                 {% endfor %}
@@ -409,7 +417,7 @@ in_use:
     <div class="section-white">
         <div class="container">
             <div class="architecturedescription">
-                <img src="assets/architectureicon2.svg" class="section-icon" alt="icon to represent jupyter architecture">
+                <img src="assets/architectureicon2.svg" class="section-icon" alt="icon to represent jupyter architecture" loading="lazy">
                 <h3 class="section-header">{{ page.open_standards.headline }}</h3>
                 <h4 class="support-paragraph">{{ page.open_standards.description }}</h4>
             </div>
@@ -419,7 +427,7 @@ in_use:
                     <div class="card">
                         <div class="arcfeature" id="arcfeature1">
                             <div class="front">
-                                <img src="{{ feat.image.src }}" alt="{{ feat.image.alt }}">
+                                <img src="{{ feat.image.src }}" alt="{{ feat.image.alt }}" loading="lazy">
                                 <h4>{{ feat.headline }}</h4>
                                 <p>{{ feat.description }}</p>
                             </div>


### PR DESCRIPTION
For #532. This patch implements [native lazy loading](https://web.dev/browser-level-image-lazy-loading/) on the homepage. The result, according to a Google audit, is that only 11 images are requested at page load. Currently it loads more than 50.