### PR TITLE
Punch up the jumbotron copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ cfp: true
 permalink: /
 
 jumbotron:
-  text: Open-source software, open standards, and services for interactive computing across dozens of programming languages
+  text: Free software, open standards, and web services for interactive computing across all programming languages
   images:
     - class: fade-in one
       alt: circle of programming language icons


### PR DESCRIPTION
Now that we've got the headline copy lean and trim, I'd like to punch it back up. This proposal offers a clear, distinct adjective for each of the major nouns. Then it dials up the backend hype.