### PR TITLE
Add explicit weight and height to large images at the top of the homepage

### DIFF
--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -117,77 +117,7 @@ body {
     padding-left: 0;
 }
 
-/*Main logo animation on the front page of the Jupyter website */
-.main-logo {
-	height: calc(100% - 20px);
-	margin-top: 10px;
-    padding-left: 20px;
-}
 
-@-webkit-keyframes fadeIn { from { opacity:0;} to { opacity:1;} }
-@-moz-keyframes fadeIn { from { opacity:0; } to { opacity:1; } }
-@keyframes fadeIn { from { opacity:0;} to { opacity:1;} }
-/*This entire section related to fading is for the front page with the Jupyter logo*/
-.fade-in {
-    -webkit-animation:fadeIn ease-in 1;  /* call our keyframe named fadeIn, use animation ease-in and repeat it only 1 time */
-    -moz-animation:fadeIn ease-in 1;
-    animation:fadeIn ease-in 1;
-
-    -webkit-animation-duration:1s;
-    -moz-animation-duration:1s;
-    animation-duration:1s;
-
-    -webkit-animation-fill-mode:forwards;  /* this makes sure that after animation is done we remain at the last keyframe value (opacity: 1)*/
-    -moz-animation-fill-mode:forwards;
-    animation-fill-mode:forwards;
-
-    opacity:0;  /* make things invisible upon start */
-}
-
-.fade-in.one {
-    -webkit-animation-delay: 0.3s;
-    -moz-animation-delay: 0.3s;
-    animation-delay: 0.3s;
-}
-
-.fade-in.two {
-    -webkit-animation-delay: 0.7s;
-    -moz-animation-delay:0.7s;
-    animation-delay: 0.7s;
-}
-
-.fade-in.three {
-    -webkit-animation-delay: 1.1s;
-    -moz-animation-delay: 1.1s;
-    animation-delay: 1.1s;
-}
-
-.jumbotron {
-    background-color: white;
-    margin-top:30px;
-    overflow: hidden;
-}
-
-.jumbotron img {
-    margin: 0 auto;
-}
-
-.jumbotron-text {
-    padding-bottom: 32px;
-    text-align: center;
-}
-
-.img-container {
-    height: 100%;
-    margin: 0 auto;
-    position: absolute;
-    text-align: center;
-    width: 95%;
-}
-
-.img-container img {
-    vertical-align: middle;
-}
 
 /* Reusable elements */
 
@@ -805,7 +735,6 @@ body {
 }
 
 @media (max-width: 768px) {
-
     p {
         font-size: 16px;
         font-weight: 400;
@@ -852,9 +781,6 @@ body {
     }
     body {
         padding-top: 50px;
-    }
-    .jumbotron {
-        margin-right: 5%;
     }
 }
 

--- a/_sass/components/_jumbotron.scss
+++ b/_sass/components/_jumbotron.scss
@@ -1,0 +1,66 @@
+/*Main logo animation on the front page of the Jupyter website */
+
+@-webkit-keyframes fadeIn { from { opacity:0;} to { opacity:1;} }
+@-moz-keyframes fadeIn { from { opacity:0; } to { opacity:1; } }
+@keyframes fadeIn { from { opacity:0;} to { opacity:1;} }
+/*This entire section related to fading is for the front page with the Jupyter logo*/
+.fade-in {
+    -webkit-animation:fadeIn ease-in 1;  /* call our keyframe named fadeIn, use animation ease-in and repeat it only 1 time */
+    -moz-animation:fadeIn ease-in 1;
+    animation:fadeIn ease-in 1;
+
+    -webkit-animation-duration:1s;
+    -moz-animation-duration:1s;
+    animation-duration:1s;
+
+    -webkit-animation-fill-mode:forwards;  /* this makes sure that after animation is done we remain at the last keyframe value (opacity: 1)*/
+    -moz-animation-fill-mode:forwards;
+    animation-fill-mode:forwards;
+
+    opacity:0;  /* make things invisible upon start */
+}
+
+.jumbotron {
+    background-color: white;
+    margin-top:30px;
+    overflow: hidden;
+    @media (max-width: 768px) {
+        margin-right: 5%;
+    }
+    .main-logo {
+        height: calc(100% - 20px);
+        margin-top: 10px;
+        padding-left: 20px;
+    }
+    .fade-in.one {
+        -webkit-animation-delay: 0.3s;
+        -moz-animation-delay: 0.3s;
+        animation-delay: 0.3s;
+    }
+    .fade-in.two {
+        -webkit-animation-delay: 0.7s;
+        -moz-animation-delay:0.7s;
+        animation-delay: 0.7s;
+    }
+    .fade-in.three {
+        -webkit-animation-delay: 1.1s;
+        -moz-animation-delay: 1.1s;
+        animation-delay: 1.1s;
+    }
+    .jumbotron-image-container {
+        height: 100%;
+        margin: 0 auto;
+        position: absolute;
+        text-align: center;
+        width: 95%;
+        img {
+            margin: 0 auto;
+            vertical-align: middle;
+        }
+    }
+}
+
+.jumbotron-text {
+    padding-bottom: 32px;
+    text-align: center;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -9,3 +9,4 @@
 @import "about";
 @import "gallery";
 @import "syntax";
+@import "components/jumbotron";

--- a/index.html
+++ b/index.html
@@ -234,7 +234,7 @@ in_use:
         <div class="row">
             <div class="col-md-12">
                 {% for img in page.jumbotron.images %}
-                <div class="img-container">
+                <div class="jumbotron-image-container">
                     <span>
                         <img class="img-responsive {{ img.class }}"
                              src="{{ img.src }}"

--- a/index.html
+++ b/index.html
@@ -10,15 +10,23 @@ jumbotron:
     - class: fade-in one
       alt: circle of programming language icons
       src: assets/circle1.svg
+      width: 677
+      height: 286
     - class: fade-in two
       alt: circle of programming language icons
       src: assets/circle2.svg
+      width: 677
+      height: 286
     - class: fade-in three
       alt: circle of programming language icons
       src: assets/circle3.svg
+      width: 677
+      height: 286
     - class: main-logo
       alt: jupyter logo
       src: assets/main-logo.svg
+      width: 677
+      height: 286
 
 jupyterlab:
   headline: 'JupyterLab: A Next-Generation Notebook Interface'
@@ -26,6 +34,8 @@ jupyterlab:
   image:
     alt: examples of jupyterlab workspaces in single document and multiple document workspaces
     src: assets/labpreview
+    width: 885
+    height: 627
   buttons:
   - class:
     href: try
@@ -40,6 +50,8 @@ notebook:
   image:
     alt: example notebook of Lorenz differential equations
     src: assets/jupyterpreview
+    width: 1018
+    height: 721
   buttons:
   - class:
     href: try
@@ -109,6 +121,8 @@ voila:
   image:
     alt: examples of Voilà dashboards
     src: assets/voilapreview
+    width: 885
+    height: 716
   buttons:
   - class:
     href: try
@@ -238,12 +252,19 @@ in_use:
                     <span>
                         <img class="img-responsive {{ img.class }}"
                              src="{{ img.src }}"
+                             width={{ img.width }}
+                             height={{ img.height }}
                              alt="{{ img.alt }}"
                              loading="eager" />
                     </span>
                 </div>
                 {% endfor %}
-                <img class="img-responsive" src="assets/white-background.svg" alt="white background" loading="eager">
+                <img class="img-responsive"
+                     src="assets/white-background.svg"
+                     width=747
+                     height=313
+                     alt="white background"
+                     loading="eager" />
             </div>
         </div>
     </div>
@@ -267,6 +288,8 @@ in_use:
                             <source type="image/webp" srcset="{{ page.jupyterlab.image.src }}.webp">
                             <img src="{{ page.jupyterlab.image.src }}.jpg"
                                  alt="{{ page.jupyterlab.image.alt }}"
+                                 width={{ page.jupyterlab.image.width }}
+                                 height={{ page.jupyterlab.image.height }}
                                  class="img-responsive"
                                  id="portal"
                                  loading="lazy" />
@@ -297,6 +320,8 @@ in_use:
                             <source type="image/webp" srcset="{{ page.notebook.image.src }}.webp">
                             <img src="{{ page.notebook.image.src }}.jpg"
                                  alt="{{ page.notebook.image.alt }}"
+                                 width={{ page.notebook.image.width }}
+                                 height={{ page.notebook.image.height }}
                                  class="img-responsive"
                                  id="portal"
                                  loading="lazy" />
@@ -373,6 +398,8 @@ in_use:
                             <source type="image/webp" srcset="{{ page.voila.image.src }}.webp">
                             <img src="{{ page.voila.image.src }}.jpg"
                                  alt="{{ page.voila.image.alt }}"
+                                 width={{ img.width }}
+                                 height={{ img.height }}
                                  class="img-responsive"
                                  id="portal" 
                                  loading="lazy" />


### PR DESCRIPTION
This optimization is one step towards #524 per Google's audit. The resulting page should look virtually the same. I also took the step of breaking out the custom jumbotron code into an SCSS component for future optimization.