### PR TITLE
FIX: Lab image should load "eager"

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@ in_use:
                                  height={{ page.jupyterlab.image.height }}
                                  class="img-responsive"
                                  id="portal"
-                                 loading="lazy" />
+                                 loading="eager" />
                         </picture>
                     </div>
                     <div class="col-md-6 nb-highlight-text">


### PR DESCRIPTION
After some repeat testing with Google's page speed tool, it appears that the lab section, the second on the page, should be more aggressive about loading its images. You can see the Google report here:

![Screenshot from 2021-12-26 10-41-29](https://user-images.githubusercontent.com/9993/147417232-f8dbf34e-fe96-4a5c-a9cb-eb1fadf6a5da.png)

They explain why [here](https://web.dev/lcp-lazy-loading/?utm_source=lighthouse&utm_medium=lr).

I did not anticipate that this image, which is near the top but not at the top, would have such a result when I made the initail patch. That was my oversight. This PR will correct things.