### PR TITLE
Update security.txt with new links

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,2 +1,8 @@
+# Our security address
 Contact: mailto:security@ipython.org
-Encryption: https://jupyter-notebook.readthedocs.io/en/stable/_downloads/ipython_security.asc
+
+# Our OpenPGP key
+Encryption: https://jupyter.org/assets/ipython_security.asc
+
+# Our security policy
+Policy: https://jupyter.org/security


### PR DESCRIPTION
Per the recommendations at https://securitytxt.org/ I have updated this file to link to the policy now published by the site. I also changed the PGP key link to the one hosted by this repository, which is what is linked in the policy page copy.