### PR TITLE
Tidy up page header

### DIFF
--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -1,0 +1,10 @@
+<header class="page-header">
+  {% if include.image %}
+    <img src="{{ include.image }}"
+         {% if include.image_alt %}alt="{{ include.image_alt }}"{% endif %}
+         loading="eager" />
+  {% else %}
+    <h1>{{ include.title }}</h1>
+  {% endif %}
+  <p>{{ include.tagline }}</p>
+</header>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 ---
-<div class="post">
   <header class="header header-grey">
     {% if page.title_image %}
     <img src="{{ page.title_image }}" class="title_image" {% if page.title_image_alt %}alt="{{ page.title_image_alt }}"{% endif %} />
@@ -18,5 +17,3 @@ layout: default
       </div>
     </div>
   </article>
-
-</div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 <div class="post">
-  <header class="post-header header header-grey">
+  <header class="header header-grey">
     {% if page.title_image %}
     <img src="{{ page.title_image }}" class="title_image" {% if page.title_image_alt %}alt="{{ page.title_image_alt }}"{% endif %} />
     {% else %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,19 +1,18 @@
 ---
 layout: default
 ---
-  <header class="header header-grey">
-    {% if page.title_image %}
-    <img src="{{ page.title_image }}" class="title_image" {% if page.title_image_alt %}alt="{{ page.title_image_alt }}"{% endif %} />
-    {% else %}
-    <h2>{{ page.title }}</h2>
-    {% endif %}
-    <p>{{ page.tagline }}</p>
-  </header>
 
-  <article class="post-content">
-    <div class="section-white top-section-border">
-      <div class="page_content container">
-        {{ content }}
-      </div>
+{% include page-header.html
+    title=page.title
+    tagline=page.tagline
+    image=page.title_image
+    image_alt=page.title_image_alt
+%}
+
+<article class="post-content">
+  <div class="section-white top-section-border">
+    <div class="page_content container">
+      {{ content }}
     </div>
-  </article>
+  </div>
+</article>

--- a/_sass/_markdown.scss
+++ b/_sass/_markdown.scss
@@ -31,12 +31,6 @@ div.page_content.container > ul {
 }
 
 
-img.title_image {
-  max-height: 200px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-}
-
 .clear {
   clear: both;
 }

--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -430,11 +430,6 @@ body {
         font-weight: 500;
         line-height: 1.25;
     }
-    h1 {
-        font-size: 48px;
-        font-weight: 500;
-        line-height: 1.05em;
-    }
     .follow {
         float: right;
         margin-top: 15px;
@@ -467,11 +462,6 @@ body {
         font-size: 26px;
         font-weight: 500;
         line-height: 1.153em;
-    }
-    h1 {
-        font-size: 32px;
-        font-weight: 500;
-        line-height: 1.25em;
     }
     .nb-highlight-text {
         text-align: center;
@@ -608,11 +598,6 @@ body {
         font-size: 26px;
         font-weight: 500;
         line-height: 1.153em;
-    }
-    h1 {
-        font-size: 32px;
-        font-weight: 500;
-        line-height: 1.25em;
     }
     .nav>li>a {
         letter-spacing: 1px;

--- a/_sass/_nav.scss
+++ b/_sass/_nav.scss
@@ -81,31 +81,6 @@ body {
 
 /* Reusable elements */
 
-/* Header section of each page */
-.header {
-    padding-top: 42px;
-    padding-bottom: 42px;
-    text-align: center;
-}
-
-.header-darkgray {
-  /* Only using dark gray for documentation page, add padding top to center in header */
-  background-color: #757575;
-  color: white;
-}
-
-.header-grey {
-  background-color: #f5f5f5;
-}
-
-.header-white {
-  background-color: white;
-}
-
-.header p {
-  margin: 0 30%;
-}
-
 /* Section elements */
 /* Section classes used for particular sections within a page. Sections should differ in background color when used next to each other */
 .section-white {

--- a/_sass/components/_page-header.scss
+++ b/_sass/components/_page-header.scss
@@ -1,13 +1,24 @@
-.header {
-    padding-top: 42px;
-    padding-bottom: 42px;
+@import "settings/colors";
+
+.page-header {
+    padding: 3em 1em;
     text-align: center;
-}
-
-.header p {
-  margin: 0 30%;
-}
-
-.header-grey {
-  background-color: #f5f5f5;
+    background-color: $light-gray;
+    h1 {
+        font-size: 2.5em;
+        line-height: 1.3;
+        @media (max-width: 767px) {
+            font-size: 2em;
+        }
+    }
+    img {
+        max-height: 200px;
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+    p {
+        margin: 0 auto;
+        max-width: 500px;
+        line-height: 1.5;
+    }
 }

--- a/_sass/components/_page-header.scss
+++ b/_sass/components/_page-header.scss
@@ -1,0 +1,13 @@
+.header {
+    padding-top: 42px;
+    padding-bottom: 42px;
+    text-align: center;
+}
+
+.header p {
+  margin: 0 30%;
+}
+
+.header-grey {
+  background-color: #f5f5f5;
+}

--- a/_sass/settings/_colors.scss
+++ b/_sass/settings/_colors.scss
@@ -7,3 +7,4 @@ $dark-gray: #4D4D4D;
 $medium-dark-gray: #616161;
 $medium-gray: #757575;
 $gray: #9E9E9E;
+$light-gray: #f5f5f5;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -14,3 +14,4 @@
 @import "components/footer";
 @import "components/jumbotron";
 @import "components/jupyterhub";
+@import "components/page-header";

--- a/documentation.html
+++ b/documentation.html
@@ -6,7 +6,7 @@ permalink: /documentation
 ---
 
 <div class="post">
-  <header class="post-header header header-grey">
+  <header class="header header-grey">
     <div class="container">
       <h2>{{ page.title }}</h2>
       <p>

--- a/documentation.html
+++ b/documentation.html
@@ -1,19 +1,18 @@
 ---
 layout: default
 title: Documentation
-description: A comprehensive list of Jupyter projects, subprojects and repositories
+tagline: A comprehensive list of Jupyter projects, subprojects and repositories
 permalink: /documentation
 ---
 
 <div class="post">
-  <header class="header header-grey">
-    <div class="container">
-      <h2>{{ page.title }}</h2>
-      <p>
-        {{ page.description }}
-      </p>
-    </div>
-  </header>
+
+    {% include page-header.html
+        title=page.title
+        tagline=page.tagline
+        image=page.title_image
+        image_alt=page.title_image_alt
+    %}
 
     <article class="post-content">
       <div class="section-white top-section-border">

--- a/documentation.html
+++ b/documentation.html
@@ -10,8 +10,6 @@ permalink: /documentation
     {% include page-header.html
         title=page.title
         tagline=page.tagline
-        image=page.title_image
-        image_alt=page.title_image_alt
     %}
 
     <article class="post-content">

--- a/try.html
+++ b/try.html
@@ -61,7 +61,7 @@ boxes:
 ---
 
 <div class="post">
-  <header class="post-header header header-grey">
+  <header class="header header-grey">
     <div class="container">
       <h2>{{ page.title }}</h2>
       <p>

--- a/try.html
+++ b/try.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Try Jupyter
-description: 'You can try Jupyter out right now, without installing anything. Select an example below and you will get a temporary Jupyter server just for you, running on <a href="https://mybinder.org">mybinder.org</a>. If you like it, you can <a href="https://jupyter.org/install.html">install Jupyter</a> yourself.'
+tagline: 'You can try Jupyter out right now, without installing anything. Select an example below and you will get a temporary Jupyter server just for you, running on <a href="https://mybinder.org">mybinder.org</a>. If you like it, you can <a href="https://jupyter.org/install.html">install Jupyter</a> yourself.'
 permalink: /try
 
 boxes:
@@ -61,14 +61,12 @@ boxes:
 ---
 
 <div class="post">
-  <header class="header header-grey">
-    <div class="container">
-      <h2>{{ page.title }}</h2>
-      <p>
-        {{ page.description }}
-      </p>
-    </div>
-  </header>
+    {% include page-header.html
+        title=page.title
+        tagline=page.tagline
+        image=page.title_image
+        image_alt=page.title_image_alt
+    %}
 
     <article class="post-content">
       <div class="section-white top-section-border">

--- a/try.html
+++ b/try.html
@@ -64,8 +64,6 @@ boxes:
     {% include page-header.html
         title=page.title
         tagline=page.tagline
-        image=page.title_image
-        image_alt=page.title_image_alt
     %}
 
     <article class="post-content">

--- a/widgets.html
+++ b/widgets.html
@@ -1,6 +1,7 @@
 ---
 layout: default
-title: Widgets
+title: Interactive Widgets
+tagline: Jupyter widgets enable interactive data visualization in the Jupyter notebooks.
 permalink: /widgets
 ---
 
@@ -11,18 +12,12 @@ permalink: /widgets
 </script>
 <script src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js" crossorigin="anonymous"></script>
 
-<section>
-  <div class="header header-grey">
-    <div class="container">
-        <div class="row">
-            <div class="col-xs-12">
-                <h2>Interactive Widgets</h2>
-                <p>Jupyter widgets enable interactive data visualization in the Jupyter notebooks.</p>
-            </div>
-        </div>
-    </div>
-  </div>
-</section>
+{% include page-header.html
+    title=page.title
+    tagline=page.tagline
+    image=page.title_image
+    image_alt=page.title_image_alt
+%}
 
 <section>
   <div class="section-white top-section-border">

--- a/widgets.html
+++ b/widgets.html
@@ -15,8 +15,6 @@ permalink: /widgets
 {% include page-header.html
     title=page.title
     tagline=page.tagline
-    image=page.title_image
-    image_alt=page.title_image_alt
 %}
 
 <section>


### PR DESCRIPTION
This patch refactors the page headers for simplicity and clarity. The actual appearance on the site should change very little. Here's what it does:

- Splits out the page-header into an independent CSS component
- Clears out crufty CSS and HTML scaffolding that isn't in use
- Distills down the CSS to only what's needed to make the thing work
- Substitutes in em units, SCSS variables and other small nice bits
- Corrects the HTML hierarchy by switching to an h1 tag
- Allows the tagline to run wider on mobile sizes, which fixes #537 
- Introduces a new include that eliminates redundant code in cases where the header is applied to a default template, like the widgets and binder pages.