### PR TITLE
Responsive Google Calendar iframe

### DIFF
--- a/_sass/components/_iframes.scss
+++ b/_sass/components/_iframes.scss
@@ -3,6 +3,9 @@
   overflow: hidden;
   width: 100%;
   padding-top: 75%; /* 4:3 Aspect Ratio */
+  @media (max-width: 767px) {
+    padding-top: 130%; /* A custom aspect ratio for Google Calendar */
+  }
 }
 
 .responsive-iframe {

--- a/_sass/components/_iframes.scss
+++ b/_sass/components/_iframes.scss
@@ -1,0 +1,16 @@
+.iframe-container {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  padding-top: 75%; /* 4:3 Aspect Ratio */
+}
+
+.responsive-iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -14,3 +14,4 @@
 @import "components/jumbotron";
 @import "components/jupyterhub";
 @import "components/page-header";
+@import "components/iframes";

--- a/community.md
+++ b/community.md
@@ -135,7 +135,17 @@ This page is for in person, one-of-a-kind events, for community engagement, see 
 
 This is a calendar of regular online events.  It might not be exhaustive.
 
-<iframe title="Calendar of Project Jupyter events" id="calendariframe" src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=local&amp;src=ZGdwZDM2ZjQzZXQ5Z3JhYm42dGRpbjZwbWNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=bTNoZWs2OWRhZzczODF1bXQ4a2NqZDc1dTRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=YXFwa3VpNXE3b2kzMnBrOXRjcDUzaG5zc2NAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=ZDE4NzR1cjZmZGh1ajBzbmpuaWxhYzJubGNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=cGlhaGluZWpqcjZzc3ZpOGlrbWpqb3A2cm9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23AD1457&amp;color=%23EF6C00&amp;color=%23616161&amp;color=%23F6BF26&amp;color=%239E69AF" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<div class="iframe-container">
+  <iframe title="Calendar of Project Jupyter events"
+          class="responsive-iframe"
+          id="calendariframe"
+          src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=local&amp;src=ZGdwZDM2ZjQzZXQ5Z3JhYm42dGRpbjZwbWNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=bTNoZWs2OWRhZzczODF1bXQ4a2NqZDc1dTRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=YXFwa3VpNXE3b2kzMnBrOXRjcDUzaG5zc2NAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=ZDE4NzR1cjZmZGh1ajBzbmpuaWxhYzJubGNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=cGlhaGluZWpqcjZzc3ZpOGlrbWpqb3A2cm9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23AD1457&amp;color=%23EF6C00&amp;color=%23616161&amp;color=%23F6BF26&amp;color=%239E69AF"
+          style="border:solid 1px #777"
+          width="800"
+          height="600"
+          frameborder="0"
+          scrolling="no"></iframe>
+</div>
 <script>document.getElementById("calendariframe").src = document.getElementById("calendariframe").src.replace("ctz=local", "ctz=" + Intl.DateTimeFormat().resolvedOptions().timeZone)</script>
 
 See [this page](https://jupyter.readthedocs.io/en/latest/community/content-community.html#jupyter-wide-meetings) for


### PR DESCRIPTION
The Google Calendar iframe on the /community page is now a fixed width, which breaks at mobile sizes.

This change follows [the W3C advice](https://www.w3schools.com/howto/howto_css_responsive_iframes.asp) for making it responsive at a 4:3 aspect ratio. There is no change to the content.