### PR TITLE
Cut the unnecessary prepending of baseurl

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -96,6 +96,6 @@ nav:
         </div>
       </div>
     </footer>
-    <script src="{{site.baseurl}}/assets/js/bootstrap-native.min.js" defer></script>
+    <script src="/assets/js/bootstrap-native.min.js" defer></script>
   </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,10 +28,10 @@ nav:
     <meta property="og:description" content="{{ site.description|strip_html }}">
     <meta property="og:url" content="{{ site.url }}" />
     <meta property="og:image" content="{{ "/assets/share.png" | prepend: site.url }}" />
-    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-    <link rel="stylesheet" href="{{ "/assets/css/bootstrap.css" | prepend: site.baseurl }}">
-    <link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl }}">
-    <link rel="icon" type="image/x-icon" href="{{ "/favicon.ico" | prepend: site.baseurl }}">
+    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
+    <link rel="stylesheet" href="/assets/css/bootstrap.css">
+    <link rel="stylesheet" href="/assets/css/main.css">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" href="/assets/favicons/apple-touch-icon-152x152.png">
     <link rel="apple-touch-icon" sizes="120x120" href="/assets/favicons/apple-touch-icon-120x120.png">
     <link rel="apple-touch-icon" sizes="152x152" href="/assets/favicons/apple-touch-icon-152x152.png">


### PR DESCRIPTION
A small optimization of our header code. This stuff isn't needed. We don't have a baseurl. 