### PR TITLE
Standard meta tag structure for the validator

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,7 @@ nav:
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta itemprop="description" name="description" content="{% if page.tagline %}{{ page.tagline|strip_html }}{% else %}{{ site.description|strip_html }}{% endif %}" />
+    <meta name="description" content="{% if page.tagline %}{{ page.tagline|strip_html }}{% else %}{{ site.description|strip_html }}{% endif %}" />
     <title>{{ site.title }} {% if page.title %}| {{ page.title }}{% endif %}</title>
     <meta property="og:title" content="Project Jupyter" />
     <meta property="og:description" content="{{ site.description|strip_html }}">


### PR DESCRIPTION
Right now, the validator is not happy. I've reverted to a more traditional tag structure.
![Screenshot from 2022-01-09 07-55-34](https://user-images.githubusercontent.com/9993/148690006-412121e6-bddd-4ef1-bbad-9567507509d3.png)
