### PR TITLE
Update pip instructions for macOS

### DIFF
--- a/install.md
+++ b/install.md
@@ -33,7 +33,9 @@ If you use `pip`, you can install it with:
 pip install jupyterlab
 ```
 
-If installing using `pip install --user`, you must add the user-level `bin` directory to your `PATH` environment variable in order to launch `jupyter lab`. If you are using a Unix derivative (FreeBSD, GNU / Linux, OS X), you can achieve this by using ``export PATH="$HOME/.local/bin:$PATH"`` command.
+If you are using a system such as macOS that includes both Python 2 and Python 3, run `pip3` instead of `pip`.
+
+If installing using `pip install --user`, you must add the user-level `bin` directory to your `PATH` environment variable in order to launch `jupyter lab`. If you are using a Unix derivative (e.g., FreeBSD, GNU/Linux, macOS), you can do this by running ``export PATH="$HOME/.local/bin:$PATH"``.
 
 ### Run JupyterLab
 


### PR DESCRIPTION
Changes for https://github.com/jupyterlab/jupyterlab/issues/11815 — updates web site's installation instructions to suggest that macOS users use `pip3` instead of `pip`.