### PR TITLE
Remove html-proofer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "jekyll-redirect-from"
 gem "jekyll-paginate"
 gem "jekyll-sitemap"
 gem "jekyll-feed"
-gem "html-proofer"
 
 group :jekyll_plugins do
   gem 'hawkins'


### PR DESCRIPTION
As far as I can tell, this plugin is not being used.