### PR TITLE
Two-column footer on mobile

### DIFF
--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -12,18 +12,11 @@
       flex-wrap: wrap;
       justify-content: space-between;
       align-items: start;
-      @media (max-width: 767px) {
-        flex-direction: column;
-      }
     }
     .footer-links {
       color: $black;
-      @media (max-width: 420px) {
-        margin-top: 2em;
-        &:first-of-type {
-          margin-top: 0;
-        }
-      }
+      min-width: 150px;
+      margin: 0.5em 0;
       h2 {
         font-size: 1.1em;
         font-weight: bold;


### PR DESCRIPTION
Fixes #652 

Before:
![Screenshot from 2022-01-14 10-23-59](https://user-images.githubusercontent.com/9993/149567576-187de4ba-a662-4824-9b5e-e9d465e73eb9.png)

After:
![Screenshot from 2022-01-14 10-34-41](https://user-images.githubusercontent.com/9993/149567595-a4fe1d8f-469f-42a4-8f00-4470596ce7e5.png)
