### PR TITLE
Trim copy to fit box properly

### DIFF
--- a/try.html
+++ b/try.html
@@ -22,7 +22,7 @@ kernels_copy: |
 
 application_boxes:
     - title: JupyterLab
-      description: The latest web-based interactive development environment for notebooks, code, and data
+      description: The latest web-based interactive development environment
       src: try/jupyter.png
       alt: JupyterLab
       url: https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/HEAD?urlpath=lab/tree/demo


### PR DESCRIPTION
See comment below for rationale

> It's running taller than the other boxes on some screen sizes and stretching out. This problem will get worse if we go up to 18px for body copy, which I think we should.

