### PR TITLE
Restore margin-top to jumbotron main art

### DIFF
--- a/_sass/components/_jumbotron.scss
+++ b/_sass/components/_jumbotron.scss
@@ -49,11 +49,6 @@
   @media (max-width: $breakpoint-m) {
     margin-right: 5%;
   }
-  .main-logo {
-    height: calc(100% - 20px);
-    margin-top: 10px;
-    padding-left: 20px;
-  }
   .fade-in.one {
     -webkit-animation-delay: 0.3s;
     -moz-animation-delay: 0.3s;
@@ -76,8 +71,13 @@
     text-align: center;
     width: 95%;
     img {
-      margin: inherit auto;
+      margin: 0 auto;
       vertical-align: middle;
+      &.main-logo {
+        height: calc(100% - 20px);
+        margin-top: 10px;
+        padding-left: 20px;
+      }
     }
   }
 }

--- a/_sass/components/_jumbotron.scss
+++ b/_sass/components/_jumbotron.scss
@@ -76,7 +76,7 @@
     text-align: center;
     width: 95%;
     img {
-      margin: 0 auto;
+      margin: inherit auto;
       vertical-align: middle;
     }
   }


### PR DESCRIPTION
This tweak restores the margin-top put into the art by the original designer. I suspect I unintentionally knocked it out in the change to SCSS. While the topper isn't quite pixel perfect, and probably would benefit from a more thorough rewrite, this fixes #676 and I think is worth shipping.