### PR TITLE
Add header links

### DIFF
--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -7,4 +7,11 @@
     <h1>{{ include.title }}</h1>
   {% endif %}
   <p>{{ include.tagline }}</p>
+
+  <script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function(event) {
+      anchors.add();
+    });
+  </script>
 </header>


### PR DESCRIPTION
There are many times I would like to send a link to a specific part of a page, but it is not easy to get the anchor link. This adds a link available on hovering over a header, as is done on many sites.

This first pass just uses a CDN. If it works well, we might make it more self-contained.