### PR TITLE
Use JupyterLite for try.jupyter.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _site
 Gemfile.lock
 .DS_Store
 .jekyll-metadata
+.jekyll-cache
 vendor
 .bundle
 .sass-cache

--- a/try.html
+++ b/try.html
@@ -24,7 +24,7 @@ application_boxes:
       description: The latest web-based interactive development environment
       src: try/jupyter.png
       alt: Jupyter logo - Launch JupyterLab demo Binder
-      url: https://jupyter.org/try-jupyter/lab
+      url: https://jupyter.org/try-jupyter/lab?path=notebooks%2FIntro.ipynb
 
     - title: Jupyter Notebook
       description: The original web application for creating and sharing computational documents

--- a/try.html
+++ b/try.html
@@ -24,13 +24,13 @@ application_boxes:
       description: The latest web-based interactive development environment
       src: try/jupyter.png
       alt: Jupyter logo - Launch JupyterLab demo Binder
-      url: https://jtpio.github.io/try-jupyter/lab
+      url: https://jupyter.org/try-jupyter/lab
 
     - title: Jupyter Notebook
       description: The original web application for creating and sharing computational documents
       src: try/python.svg
       alt: Python logo - Launch Jupyter Notebook demo Binder
-      url: https://jtpio.github.io/try-jupyter/retro/notebooks/?path=notebooks/Intro.ipynb
+      url: https://jupyter.org/try-jupyter/retro/notebooks/?path=notebooks/Intro.ipynb
 
     - title: Voilà
       description: Share insights by converting notebooks into interactive dashboards

--- a/try.html
+++ b/try.html
@@ -21,7 +21,7 @@ kernels_copy: |
 
 application_boxes:
     - title: JupyterLab
-      description: The latest web-based interactive development environment
+      description: The latest web-based interactive development environment. ⚠️experimental⚠️this uses the <a href="https://jupyterlite.readthedocs.io/en/latest/">JupyterLite</a> package, please report any unexpected behavior.
       src: try/jupyter.png
       alt: Jupyter logo - Launch JupyterLab demo Binder
       url: https://jupyter.org/try-jupyter/lab?path=notebooks%2FIntro.ipynb

--- a/try.html
+++ b/try.html
@@ -24,13 +24,13 @@ application_boxes:
       description: The latest web-based interactive development environment
       src: try/jupyter.png
       alt: Jupyter logo - Launch JupyterLab demo Binder
-      url: https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/HEAD?urlpath=lab/tree/demo
+      url: https://jtpio.github.io/try-jupyter/lab
 
     - title: Jupyter Notebook
       description: The original web application for creating and sharing computational documents
       src: try/python.svg
       alt: Python logo - Launch Jupyter Notebook demo Binder
-      url: https://mybinder.org/v2/gh/ipython/ipython-in-depth/HEAD?urlpath=tree/binder/Index.ipynb
+      url: https://jtpio.github.io/try-jupyter/retro/notebooks/?path=notebooks/Intro.ipynb
 
     - title: Voilà
       description: Share insights by converting notebooks into interactive dashboards

--- a/try.html
+++ b/try.html
@@ -14,7 +14,8 @@ applications_copy: |
     Click the boxes below to learn how they work and to learn more.
     If you like one, you can find <a href="/install">installation instructions here</a>.
 
-    ⚠️Experimental⚠️ several of the environments below use the
+    <br><br>
+    ⚠️<strong>Experimental</strong>⚠️ several of the environments below use the
     <a href="https://jupyterlite.readthedocs.io/en/latest/">JupyterLite project</a> to provide a self-contained
     Jupyter environment that runs in your browser. This is experimental technology and
     may have some bugs, so please be patient and report any unexpected behavior in


### PR DESCRIPTION
Fixes https://github.com/jupyter/jupyter.github.io/issues/513

Opening this PR early for visibility and feedback.

## Motivation

https://user-images.githubusercontent.com/591645/155325378-0ee8839f-0f0a-42ba-9589-0b705025e1ab.mp4

The JupyterLab and Jupyter Notebook demo repos:

- https://github.com/ipython/ipython-in-depth
- https://github.com/jupyterlab/jupyterlab-demo

are quite popular and often reach the limit of concurrent users:

![image](https://user-images.githubusercontent.com/591645/155324047-c5492d5a-724a-4a94-9e67-b7d8b84bbfb8.png)

Plus mybinder.org is often the target of abuse usage, which unfortunately affects all members of the federations as well as uses. See https://github.com/jupyter/jupyter.github.io/issues/513 for more context.

This PR proposes to use JupyterLite for JupyterLab and Jupyter Notebook demos, with the hope this will reduce the load on https://mybinder.org and provide faster boot time so users can try the Jupyter interfaces quickly in their browsers.

## TODO

- [x] Update the links for the JupyterLab and Jupyter Notebook demos to point to a JupyterLite deployment
- [x] Move https://github.com/jtpio/try-jupyter to https://github.com/jupyter/try-jupyter. Having a custom JupyterLite from  https://github.com/jupyter/try-jupyter will make easier to maintain the deployment, pin dependencies and handle custom configuration
- [x] Update the URLs to https://jupyter.org/try-jupyter (to not conflict with the existing https://jupyter.org/try
- [ ] Include a subset of notebooks from https://github.com/ipython/ipython-in-depth. Some IPython functionalities don't work in JupyterLite / Pyodide at the moment, and should not be part of the example notebooks
- [x] Add a Tour of the interface(s) (https://github.com/jupyterlite/jupyterlite/issues/31), or a disclaimer this is a "lite" version of Jupyter and some functionalities might not work the same as in a "regular" Jupyter installation

## Open questions

- For now [RetroLab](https://github.com/jupyterlab/retrolab) is used as the substitute for Jupyter Notebook, since [Notebook v7 will be based on RetroLab](https://jupyter.org/enhancement-proposals/79-notebook-v7/notebook-v7.html). Maybe we should wait for at least the first v7 pre-releases before merging this? To reduce confusion among users who might not know what RetroLab is.
- How much traffic do we expect to have? How many users visit the https://jupyter.org/try page?