### PR TITLE
CI: Display LightHouse stats in nicer way

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -101,7 +101,9 @@ jobs:
         with:
           name: Built site ${{ github.run_number }}
           path: ./_site
+      
       - name: Audit with Lighthouse
+        id: lighthouse_audit
         uses: treosh/lighthouse-ci-action@v8
         with:
           configPath: ".github/workflows/lighthouserc.json"
@@ -109,3 +111,38 @@ jobs:
           uploadArtifacts: true
           # Multiple runs for more stable results. If builds are too slow, we can try to reduce this.
           runs: 4
+          
+      - name: Lighthouse Score Report
+        id: lighthouse_score_report
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const result = ${{ steps.lighthouse_audit.outputs.manifest }}[0].summary
+            const links = ${{ steps.lighthouse_audit.outputs.links }}
+            const formatResult = (res) => Math.round((res * 100))
+            Object.keys(result).forEach(key => result[key] = formatResult(result[key]))
+            const score = res => res >= 90 ? '🟢' : res >= 50 ? '🟠' : '🔴'
+            const comment = [
+                `⚡️ [Lighthouse report](${Object.values(links)[0]}) for the changes in this PR:`,
+                '| Category | Score |',
+                '| --- | --- |',
+                `| ${score(result.performance)} Performance | ${result.performance} |`,
+                `| ${score(result.accessibility)} Accessibility | ${result.accessibility} |`,
+                `| ${score(result['best-practices'])} Best practices | ${result['best-practices']} |`,
+                `| ${score(result.seo)} SEO | ${result.seo} |`,
+                `| ${score(result.pwa)} PWA | ${result.pwa} |`,
+                ' ',
+                `*Lighthouse ran on [${Object.keys(links)[0]}](${Object.keys(links)[0]})*`
+            ].join('\n')
+             core.setOutput("comment", comment);
+
+      - name: LightHouse Statistic Comment
+        if: github.event_name == 'pull_request'
+        id: lighthouse_statistic_comment
+        uses: marocchino/sticky-pull-request-comment@v2.2.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.pull_request.number }}
+          header: lighthouse
+          message: ${{ steps.lighthouse_score_report.outputs.comment }}


### PR DESCRIPTION
Fixes #582 

This PR:

- Formats a comment displaying the LightHouse stats in a visual and tabular manner
- Uses `marocchino/sticky-pull-request-comment@v2.2.0` to put up the comment on the PR
- Adds a check to run the `LightHouse Statistic Comment` only over a GitHub PR
