### PR TITLE
Fix broken links

### DIFF
--- a/about.html
+++ b/about.html
@@ -77,7 +77,6 @@ distinguished_2020:
     photo: Tim_George.jpg
     gh_handle: tgeorgeux
     linkedin: https://linkedin.com/in/tgeorgeux
-    personal: https://tgeorgeux.com
   - name: Tony Hirst
     photo: Tony_Hirst.png
     twitter_handle: psychemedia

--- a/binder.md
+++ b/binder.md
@@ -57,7 +57,7 @@ In short, if you follow best-practices in computational science, your repository
 Binder is entirely powered by an open-source infrastructure stack. Its main two
 tools are BinderHub, which is an open-source tool that deploys the Binder
 service in the cloud, and repo2docker, which generates reproducible Docker
-images from a git repository. The [Binder team](https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html)
+images from a git repository. The [Binder team](https://jupyterhub-team-compass.readthedocs.io/en/latest/team/index.html)
 also runs a public BinderHub deployment at mybinder.org as a free public service for the community.
 
 ### repo2docker
@@ -120,9 +120,9 @@ to join our community and contribute code, time, comments, or appreciation.
 
 * [**The JupyterHub Team Compass**](https://jupyterhub-team-compass.readthedocs.io/en/latest/) is a resource
   for the JupyterHub community to share information, team practices, and important information.
-* [**The JupyterHub Teams Page**](https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html) lists
+* [**The JupyterHub Teams Page**](https://jupyterhub-team-compass.readthedocs.io/en/latest/team/index.html) lists
   the current members of the JupyterHub and Binder teams.
-* [**The JupyterHub Contributing guide**](https://jupyterhub-team-compass.readthedocs.io/en/latest/contributing.html) is
+* [**The JupyterHub Contributing guide**](https://jupyterhub-team-compass.readthedocs.io/en/latest/contribute/index.html) is
   a great place to start learning how you can contribute to the Binder Project.
 * [**The Binder Gitter Channel**](https://gitter.im/jupyterhub/binder) is where a lot of real-time
   conversations happen in the Binder community.

--- a/widgets.html
+++ b/widgets.html
@@ -180,7 +180,7 @@ jupyter nbextension enable --py --sys-prefix nglview{% endhighlight %}
               makes it also a fast and performant visualisation tool for HPC computing e.g. fluid dynamics.
           </p>
             <p>
-                Showcase gallery: <a href="https://k3d-jupyter.org/showcase/index.html">https://k3d-jupyter.org/showcase/index.html</a>.
+                Showcase gallery: <a href="https://k3d-jupyter.org/gallery/index.html">https://k3d-jupyter.org/gallery/index.html</a>.
             </p>
           <h3>Example</h3>
           {% highlight python %}{% include_relative assets/widgets/k3d-example.py %}{% endhighlight %}


### PR DESCRIPTION
Spotted in https://github.com/jupyter/jupyter.github.io/pull/697

In this job: https://github.com/jupyter/jupyter.github.io/runs/7646707851?check_suite_focus=true

```
=================================== FAILURES ===================================
_ /home/runner/work/jupyter.github.io/jupyter.github.io/_site/about.html: https://tgeorgeux.com/ _
[https://tgeorgeux.com:](https://tgeorgeux.com/) 404: Not Found
_ /home/runner/work/jupyter.github.io/jupyter.github.io/_site/binder.html: https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html _
https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html: 404: Not Found
_ /home/runner/work/jupyter.github.io/jupyter.github.io/_site/binder.html: https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html _
https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html: 404: Not Found
_ /home/runner/work/jupyter.github.io/jupyter.github.io/_site/binder.html: https://jupyterhub-team-compass.readthedocs.io/en/latest/contributing.html _
https://jupyterhub-team-compass.readthedocs.io/en/latest/contributing.html: 404: Not Found
_ /home/runner/work/jupyter.github.io/jupyter.github.io/_site/widgets.html: https://k3d-jupyter.org/showcase/index.html _
https://k3d-jupyter.org/showcase/index.html: 404: Not Found
```