### PR TITLE
add link to list of Jupyter Subprojects

### DIFF
--- a/security.md
+++ b/security.md
@@ -11,7 +11,7 @@ of security issues.
 
 ## Reporting vulnerabilities
 
-If you believe you've found a security vulnerability in a [Jupyter Subproject](governance/list_of_subprojects.html),
+If you believe you've found a security vulnerability in a [Jupyter Subproject](https://jupyter.org/governance/list_of_subprojects.html),
 please report it to [security@ipython.org](mailto:security@ipython.org).
 If you prefer to encrypt your security reports,
 you can use [this PGP public key](assets/ipython_security.asc).

--- a/security.md
+++ b/security.md
@@ -11,7 +11,7 @@ of security issues.
 
 ## Reporting vulnerabilities
 
-If you believe you've found a security vulnerability in a Jupyter project,
+If you believe you've found a security vulnerability in a [Jupyter Subproject](governance/list_of_subprojects.html),
 please report it to [security@ipython.org](mailto:security@ipython.org).
 If you prefer to encrypt your security reports,
 you can use [this PGP public key](assets/ipython_security.asc).


### PR DESCRIPTION
Trying to provide a suggestion to readers about the scope of vulnerability reporting and handling.