### PR TITLE
Pointers to using pip3 and Python3 if pip installation fails

### DIFF
--- a/install.md
+++ b/install.md
@@ -51,3 +51,7 @@ Once installed, launch Voilà with:
 ```bash
 voila
 ```
+
+### Installation tips
+
+You may get error messages that suggest the `pip` command does not work. This could be because you do not have `pip` installed. Or, you have Python3 (instead of Python2) and need to use `pip3` for installation. For example, try installing with `pip3 install jupyter-lab` instead.


### PR DESCRIPTION
Updating install page with suggestions of trying pip3 if pip install fails for those who now have Python3 installed. 