### PR TITLE
Add Mastodon to Jupyter web site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,6 +39,8 @@ social:
     url: https://github.com/jupyter/
   - title: Twitter
     url: https://twitter.com/projectjupyter
+  - title: Mastodon
+    url: https://fosstodon.org/@Jupyter
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -55,6 +57,7 @@ social:
     <link rel="stylesheet" href="/assets/css/bootstrap.css">
     <link rel="stylesheet" href="/assets/css/main.css">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="me" href="https://fosstodon.org/@Jupyter">
     <link rel="apple-touch-icon" href="/assets/favicons/apple-touch-icon-152x152.png">
     <link rel="apple-touch-icon" sizes="120x120" href="/assets/favicons/apple-touch-icon-120x120.png">
     <link rel="apple-touch-icon" sizes="152x152" href="/assets/favicons/apple-touch-icon-152x152.png">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,6 +58,7 @@ social:
     <link rel="stylesheet" href="/assets/css/main.css">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="me" href="https://fosstodon.org/@Jupyter">
+    <link rel="me" href="https://fosstodon.org/@ProjectJupyter">
     <link rel="apple-touch-icon" href="/assets/favicons/apple-touch-icon-152x152.png">
     <link rel="apple-touch-icon" sizes="120x120" href="/assets/favicons/apple-touch-icon-120x120.png">
     <link rel="apple-touch-icon" sizes="152x152" href="/assets/favicons/apple-touch-icon-152x152.png">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,8 +39,6 @@ social:
     url: https://github.com/jupyter/
   - title: Twitter
     url: https://twitter.com/projectjupyter
-  - title: Mastodon
-    url: https://fosstodon.org/@Jupyter
 ---
 <!DOCTYPE html>
 <html lang="en">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,6 +58,7 @@ social:
     <link rel="stylesheet" href="/assets/css/main.css">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <!-- These 'rel="me"' links validate that the Fosstodon Mastodon accounts below are officially associated with Project Jupyter -->
+    <!-- The @Jupyter account is primary and @ProjectJupyter is a backup -->
     <link rel="me" href="https://fosstodon.org/@Jupyter">
     <link rel="me" href="https://fosstodon.org/@ProjectJupyter">
     <link rel="apple-touch-icon" href="/assets/favicons/apple-touch-icon-152x152.png">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,6 +57,7 @@ social:
     <link rel="stylesheet" href="/assets/css/bootstrap.css">
     <link rel="stylesheet" href="/assets/css/main.css">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <!-- These 'rel="me"' links validate that the Fosstodon Mastodon accounts below are officially associated with Project Jupyter -->
     <link rel="me" href="https://fosstodon.org/@Jupyter">
     <link rel="me" href="https://fosstodon.org/@ProjectJupyter">
     <link rel="apple-touch-icon" href="/assets/favicons/apple-touch-icon-152x152.png">


### PR DESCRIPTION
Adds a `link rel="me"` tag to the header for verification purpose (green checkmark) on the `@Jupyter` and `@ProjectJupyter` Mastodon accounts hosted on [Fosstodon](https://fosstodon.org). As of 2022-12-19, these accounts are not in active use, but are reserved for future use. (`@Jupyter` is intended as our primary account; `@ProjectJupyter` is reserved because it is our Twitter username.)

- Related to https://github.com/jupyter/governance/issues/146.