### PR TITLE
Update affiliation of SSC members

### DIFF
--- a/about.html
+++ b/about.html
@@ -183,6 +183,7 @@ distinguished_special_election:
   - name: Zach Sailer
     photo: Zach_Sailer.jpg
     gh_handle: Zsailer
+    affiliation: Apple
     linkedin: https://linkedin.com/in/zach-sailer-8a1472151/
     twitter_handle: zrsailer
   - name: Matthew Seal
@@ -235,7 +236,6 @@ distinguished_inaugural:
     gh_handle: jhamrick
   - name: Paul Ivanov
     photo: PaulIvanov.jpeg
-    affiliation: Noteable
     gh_handle: ivanov
   - name: Thomas Kluyver
     photo: ThomasKluyver.jpeg
@@ -306,6 +306,7 @@ software_steering_council:
   - name: Eric Charles
     photo: EricCharles.png
     gh_handle: echarles
+    affiliation: Datalayer / Anaconda
     subproject: Jupyter Notebook
   - name: Frédéric Collonval
     photo: Frederic_Collonval.jpg
@@ -320,11 +321,11 @@ software_steering_council:
     subproject: Voilà
   - name: Itay Dafna
     photo: ItayDafna.jpg
+    affiliation: Netflix
     gh_handle: ibdafna
     subproject: Jupyter Widgets
   - name: Paul Ivanov
     photo: PaulIvanov.jpeg
-    affiliation: Noteable
     gh_handle: ivanov
     subproject: Jupyter Foundations
   - name: Johan Mabille
@@ -347,6 +348,7 @@ software_steering_council:
   - name: Zach Sailer
     photo: Zach_Sailer.jpg
     gh_handle: Zsailer
+    affiliation: Apple
     linkedin: https://linkedin.com/in/zach-sailer-8a1472151/
     twitter_handle: zrsailer
     subproject: Jupyter Server
@@ -377,7 +379,6 @@ trademark_subcomittee:
     gh_handle: tgeorgeux
   - name: Paul Ivanov
     photo: PaulIvanov.jpeg
-    affiliation: Noteable
     gh_handle: ivanov
   - name: Min Ragan-Kelley
     photo: MinRaganKelley.jpeg


### PR DESCRIPTION
This updates the affiliation for @ivanov (based on personal email correspondence).

We should double-check the affiliation for all SSC members too. We currently have listed:

- [x] @echarles: [no affiliation listed]
- [x] @fcollonval: QuantStack
- [x] @sylvaincorlay: QuantStack
- [x] @ibdafna: Netflix
- [x] @ivanov: [no affiliation listed]
- [x] @JohanMabille: QuantStack
- [ ] @isabela-pf: [no affiliation listed]
- [x] @minrk: Simula Research Lab
- [x] @Zsailer: Apple
- [ ] @rpwagner: [no affiliation listed]
- [x] @willingc: Noteable

If any of you would like to update your affiliation, please let us know here ASAP, as we'd like to announce the governance change in a blog post soon, which may contain this info.
