### PR TITLE
Fix typo in launch instructions

### DIFF
--- a/install.md
+++ b/install.md
@@ -21,7 +21,7 @@ pip install jupyterlab
 Once installed, launch JupyterLab with:
 
 ```bash
-jupyter-lab
+jupyter lab
 ```
 
 ## Jupyter Notebook


### PR DESCRIPTION
The command to launch JupyterLab is `jupyter lab`, not `jupyter-lab`.