### PR TITLE
Add Community Building Committee to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -447,6 +447,27 @@ trademark_subcomittee:
     affiliation: SageMath
     gh_handle: williamstein
 
+community_building:
+- name: Martha Cryan
+  photo: Martha_Cryan.jpg
+  gh_handle: marthacryan
+- name: Jason Grout
+  photo: JasonGrout.jpeg
+  affiliation: Databricks
+  gh_handle: jasongrout
+  mastodon: https://fosstodon.org/@jasongrout
+  personal: https://jasongrout.org/
+- name: Ana Ruvalcaba
+  photo: Ana_Ruvalcaba.jpg
+  affiliation: Cal Poly, San Luis Obispo
+  gh_handle: ruv7
+- name: Rollin Thomas
+  photo: Rollin_Thomas.jpg
+  linkedin: https://www.linkedin.com/in/rollin-thomas-507185b5/
+  personal: https://www.nersc.gov/about/nersc-staff/programming-environments-and-models/rollin-thomas/
+  gh_handle: rcthomas
+  twitter_handle: r_c_thomas
+
 sponsor_box:
   headline: Sponsors
   description: 'Project Jupyter receives direct funding from the following sources:'
@@ -698,6 +719,30 @@ donate_box:
         %}
       {% endfor %}
       </div>
+    </div>
+
+  {% include hr.html %}
+
+    <!-- COMMUNITY COMMITTEE MEMBERS -->
+    <div class="content content--copy">
+        <h2 class="text-center">Community Building Committee Members</h2>
+    </div>
+
+    <div class="content content--wide">
+        <div class="biocard-wrapper">
+        {% for bio in page.community_building %}
+            {% include biocard.html
+                name=bio.name
+                photo=bio.photo
+                affiliation=bio.affiliation
+                personal=bio.personal
+                gh_handle=bio.gh_handle
+                linkedin=bio.linkedin
+                twitter_handle=bio.twitter_handle
+                mastodon=bio.mastodon
+            %}
+        {% endfor %}
+        </div>
     </div>
 
   {% include hr.html %}

--- a/about.html
+++ b/about.html
@@ -451,6 +451,7 @@ community_building:
 - name: Martha Cryan
   photo: Martha_Cryan.jpg
   gh_handle: marthacryan
+  affiliation: Mito
 - name: Jason Grout
   photo: JasonGrout.jpeg
   affiliation: Databricks

--- a/about.html
+++ b/about.html
@@ -727,7 +727,7 @@ donate_box:
 
     <!-- COMMUNITY COMMITTEE MEMBERS -->
     <div class="content content--copy">
-        <h2 class="text-center"><a href="https://jupyter.org/governance/communitybuildingcommittee.html">Community Building Working Group Members</a></h2>
+        <h2 class="text-center"><a href="https://jupyter.org/governance/communitybuildingworkinggroup.html">Community Building Working Group Members</a></h2>
     </div>
 
     <div class="content content--wide">

--- a/about.html
+++ b/about.html
@@ -725,7 +725,7 @@ donate_box:
 
     <!-- COMMUNITY COMMITTEE MEMBERS -->
     <div class="content content--copy">
-        <h2 class="text-center">Community Building Committee Members</h2>
+        <h2 class="text-center"><a href="https://jupyter.org/governance/communitybuildingcommittee.html">Community Building Committee Members</a></h2>
     </div>
 
     <div class="content content--wide">

--- a/about.html
+++ b/about.html
@@ -467,6 +467,7 @@ community_building:
   personal: https://www.nersc.gov/about/nersc-staff/programming-environments-and-models/rollin-thomas/
   gh_handle: rcthomas
   twitter_handle: r_c_thomas
+  affiliation: Berkeley Lab
 
 sponsor_box:
   headline: Sponsors
@@ -725,7 +726,7 @@ donate_box:
 
     <!-- COMMUNITY COMMITTEE MEMBERS -->
     <div class="content content--copy">
-        <h2 class="text-center"><a href="https://jupyter.org/governance/communitybuildingcommittee.html">Community Building Committee Members</a></h2>
+        <h2 class="text-center"><a href="https://jupyter.org/governance/communitybuildingcommittee.html">Community Building Working Group Members</a></h2>
     </div>
 
     <div class="content content--wide">


### PR DESCRIPTION
The community building committee is the only leadership body in the [governance directory](https://jupyter.org/governance/people.html) that is not on the about page. This adds the committee to the page.

[Preview](https://deploy-preview-730--jupyter-github-io.netlify.app/about#community-building-committee-members)