### PR TITLE
install docs: mention Homebrew

### DIFF
--- a/install.md
+++ b/install.md
@@ -7,7 +7,7 @@ permalink: /install
 
 Project Jupyter's tools are available for installation via the [Python Package Index](https://pypi.org/), the leading repository of software created for the Python programming language.
 
-This page uses instructions with [pip](https://pip.pypa.io/en/stable/), [the recommended installation tool for Python](https://packaging.python.org/en/latest/guides/tool-recommendations/#installation-tool-recommendations). If you require _environment management_ as opposed to just installation, look into [conda](https://docs.conda.io/), [mamba](https://mamba.readthedocs.io/), and [pipenv](https://pipenv.pypa.io/).
+This page uses instructions with [pip](https://pip.pypa.io/en/stable/), [the recommended installation tool for Python](https://packaging.python.org/en/latest/guides/tool-recommendations/#installation-tool-recommendations). If you require _environment management_ as opposed to just installation, look into [Homebrew](https://brew.sh), [conda](https://docs.conda.io/), [mamba](https://mamba.readthedocs.io/), and [pipenv](https://pipenv.pypa.io/).
 
 ## JupyterLab
 

--- a/install.md
+++ b/install.md
@@ -7,7 +7,7 @@ permalink: /install
 
 Project Jupyter's tools are available for installation via the [Python Package Index](https://pypi.org/), the leading repository of software created for the Python programming language.
 
-This page uses instructions with [pip](https://pip.pypa.io/en/stable/), [the recommended installation tool for Python](https://packaging.python.org/en/latest/guides/tool-recommendations/#installation-tool-recommendations). If you require _environment management_ as opposed to just installation, look into [Homebrew](https://brew.sh), [conda](https://docs.conda.io/), [mamba](https://mamba.readthedocs.io/), and [pipenv](https://pipenv.pypa.io/).
+This page uses instructions with [pip](https://pip.pypa.io/en/stable/), [the recommended installation tool for Python](https://packaging.python.org/en/latest/guides/tool-recommendations/#installation-tool-recommendations). If you require _environment management_ as opposed to just installation, look into [conda](https://docs.conda.io/), [mamba](https://mamba.readthedocs.io/), [pipenv](https://pipenv.pypa.io/), and [Homebrew](https://brew.sh).
 
 ## JupyterLab
 
@@ -50,4 +50,13 @@ Once installed, launch Voilà with:
 
 ```bash
 voila
+```
+
+## Homebrew
+
+[Homebrew](https://brew.sh) is a package manager for macOS and Linux.
+You can use it to install Jupyter by running:
+
+```bash
+brew install jupyterlab
 ```


### PR DESCRIPTION
Users can install Jupyter by running `brew install jupyterlab`. See https://formulae.brew.sh/formula/jupyterlab