### PR TITLE
Add QuantStack as sponsor

### DIFF
--- a/about.html
+++ b/about.html
@@ -481,6 +481,9 @@ sponsors:
   - url: https://www.quansight.com/
     src: quansight.svg
     alt: Quansight - Home Page
+  - url: https://quantstack.net/
+    src: quantstack-color.svg
+    alt: QuantStack - Home Page
   - url: https://developer.rackspace.com/
     src: rackspace-color.svg
     alt: Rackspace technology - Developer solutions documentation Page


### PR DESCRIPTION
QuantStack had been listed as a Partner but not as a Sponsor.  They have fiscally sponsored the project, meeting the current definition of Sponsor.