### PR TITLE
Remove Carol Willing from current SSC after merging standards/foundations subprojects

### DIFF
--- a/about.html
+++ b/about.html
@@ -389,7 +389,7 @@ software_steering_council:
   - name: Paul Ivanov
     photo: PaulIvanov.jpeg
     gh_handle: ivanov
-    subproject: Jupyter Foundations
+    subproject: Jupyter Foundations and Standards
   - name: Johan Mabille
     photo: Johan_Mabille.jpg
     affiliation: QuantStack

--- a/about.html
+++ b/about.html
@@ -421,11 +421,6 @@ software_steering_council:
     linkedin: https://www.linkedin.com/in/rpwagner
     gh_handle: rpwagner
     subproject: Jupyter Security
-  - name: Carol Willing
-    photo: CarolWilling.jpeg
-    affiliation: Noteable
-    gh_handle: willingc
-    subproject: Jupyter Standards
 
 trademark_subcomittee:
   - name: Brian Granger


### PR DESCRIPTION
Thank you for your service Carol! 

The SSC merged the standards/foundations projects, and @ivanov is the representative for these. I meant to make this changed in #746, but missed it. 

