### PR TITLE
Update branches names.

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
   workflow_dispatch:
 
 concurrency:

--- a/community.md
+++ b/community.md
@@ -93,7 +93,7 @@ Jupyter also has a number of online communication channels to help keep in touch
 
 As you interact with others in the Jupyter ecosystem, remember that we have a strong
 commitment to being an **open, inclusive, and positive community**. Please read the
-[Jupyter Code of Conduct](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md)
+[Jupyter Code of Conduct](https://github.com/jupyter/governance/blob/main/conduct/code_of_conduct.md)
 for guidance on how to interact with others in a way that makes the community thrive.
 
 Below is a short list of Gitter channels, mailing lists, and GitHub repositories


### PR DESCRIPTION
Master is becoming more and more rare, so this update workflow to also work once we rename the branch. It also update a link to another repo that now uses main. (Link it not broken as GitHub redirects, but better to update).

Once this is merge can Someone go into settings and rename the master branch of this repo to main ?