### PR TITLE
mentioned Jupyter deskptop on "install" page

### DIFF
--- a/install.md
+++ b/install.md
@@ -16,6 +16,7 @@ Install JupyterLab with `pip`:
 ```bash
 pip install jupyterlab
 ```
+
 **Note**: If you install JupyterLab with conda or mamba, we recommend using [the conda-forge channel](https://conda-forge.org/).
 
 Once installed, launch JupyterLab with:
@@ -37,6 +38,16 @@ To run the notebook:
 ```bash
 jupyter notebook
 ```
+
+## Jupyter Desktop
+
+Install Jupyter Desktop with:
+
+```bash
+winget install jupyterlab
+```
+
+**Note**: you can also install Jupyter Desktop by visiting [JupyterLab Desktop Releases](https://github.com/jupyterlab/jupyterlab-desktop/releases) page.
 
 ## Voilà
 


### PR DESCRIPTION
#737 

## Code changes

now the jupyter desktop is mentioned on the **install** page. talking about the  **try** page we shouldn't be adding the jupyter desktop there the user won't be able to try the desktop version without installing it.

## User-facing changes

Before 
![Before](https://github.com/user-attachments/assets/962c016a-23c9-48f2-a491-5137dc2906f5)
After
![after](https://github.com/user-attachments/assets/27009b5e-0249-4bf2-97df-7f37cc2040a6)

## Backwards-incompatible changes
_None_

kindly tell if anymore changes are needed
