### PR TITLE
Add zulip and deduplicate BlueSky

### DIFF
--- a/social.md
+++ b/social.md
@@ -27,7 +27,7 @@ List of channels actively maintained by JMS in alphabetical order:
 - Mastodon:  https://hachyderm.io/@ProjectJupyter
 - Slack JupyterLab: https://jupyterlabworkspace.slack.com
 - YouTube: https://youtube.com/@projectjupyter
-- BlueSky : https://bsky.app/profile/projectjupyter.bsky.social
+- Zulip: https://jupyter.zulipchat.com
 
 
 List of channels considered inactive but managed by the JMS:


### PR DESCRIPTION
I noticed that Zulip was missing from the Jupyter website and thought it could be added as the community is quite active there. I was not sure if it should be added elsewhere like the 'Follow Us' section, but I can add it there if it should indeed go there!

I also noticed the BlueSky sandwich mentioned by Paul in https://github.com/jupyter/jupyter.github.io/pull/780#discussion_r1931211820 so I thought it might work to update it here 🙂