### PR TITLE
Updated wrong Bluesky profile URL

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,7 +42,7 @@ social:
   - title: Mastodon
     url: https://hachyderm.io/@ProjectJupyter
   - title: BlueSky
-    url: https://bsky.app/profile/projectjupyter.bsky.social
+    url: https://bsky.app/profile/jupyter.org
   - title: YouTube
     url: https://www.youtube.com/@projectjupyter
 legal:

--- a/social.md
+++ b/social.md
@@ -20,7 +20,7 @@ If you are organizing a Jupyter event or have something Jupyter-related that sho
 
 List of channels actively maintained by JMS in alphabetical order:
 
-- Bluesky: https://bsky.app/profile/projectjupyter.bsky.social
+- Bluesky: https://bsky.app/profile/jupyter.org
 - Discourse: https://discourse.jupyter.org
 - LinkedIn: https://linkedin.com/company/project-jupyter
 - Medium: https://blog.jupyter.org


### PR DESCRIPTION
jupyter.org is showing/linking on the global Footer (image 1) and on the social page (image 2) to a wrong profile URL on Bluesky. This resulted probably subsequently from a verification process with the jupyter.org domain on Bluesky. The result was a 404 when accessing the old URL (https://bsky.app/profile/projectjupyter.bsky.social), means the official profile couldn't be reached from the Jupyter website.

I updated this accordingly and is with this PR linking to the correct profile: https://bsky.app/profile/jupyter.org

Image 1:
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/3790297a-614d-4672-aa6f-8f191abcd56f" />

Image 2:
<img width="850" alt="Screenshot 2025-02-20 at 17 36 18" src="https://github.com/user-attachments/assets/2141b3f9-2e32-4a67-9f8e-815f004dc380" />
