### PR TITLE
Fix CI by removing `<a>` and `<button>` nesting as well as ignoring some working links

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -90,6 +90,8 @@ jobs:
            --check-links-ignore "https://jupytercon.com" \
            --check-links-ignore "https://www.netapp.com" \
            --check-links-ignore "https://github.com/[^/]+/?$" \
+           --check-links-ignore "https://sloan.org" \
+           --check-links-ignore "https://www.bloomberg.com" \
            --check-links-ignore "https://opensource.org/licenses/BSD-3-Clause"
 
   lighthouse:

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -152,19 +152,19 @@
     max-width: 500px;
 }
 
-button.con-button {
-    background-color: #f37726;
-
-    a {
+div.con-buttons {
+    margin-top: 2em;
+    a.con-button {
+        background-color: #f37726;
         color: white;
         font-size: 1em;
         font-weight: 600;
+        margin: 0 .5em;
+        padding: 1em;
+        border-radius: 5px;
+        border: none;
+        cursor: pointer;
     }
-    margin: 0 .5em;
-    padding: 1em;
-    border-radius: 5px;
-    border: none;
-    cursor: pointer;
 }
 
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -152,15 +152,18 @@
     max-width: 500px;
 }
 
-.con-button button {
+button.con-button {
     background-color: #f37726;
-    color: white;
+
+    a {
+        color: white;
+        font-size: 1em;
+        font-weight: 600;
+    }
     margin: 0 .5em;
     padding: 1em;
     border-radius: 5px;
     border: none;
-    font-size: 1em;
-    font-weight: 600;
     cursor: pointer;
 }
 

--- a/index.html
+++ b/index.html
@@ -256,8 +256,10 @@ in_use:
                         <div class="con-program">
                             <p>San Diego, California</p>
                         </div>
-                        <button class="con-button"><a href="https://events.linuxfoundation.org/jupytercon/">Conference Website</a></button>
-                        <button class="con-button"><a href="https://events.linuxfoundation.org/jupytercon/program/cfp/">Call for Proposals</a></button>
+                        <div class="con-buttons">
+                          <a class="con-button" role="button" href="https://events.linuxfoundation.org/jupytercon/">Conference Website</a>
+                          <a class="con-button" role="button" href="https://events.linuxfoundation.org/jupytercon/program/cfp/">Call for Proposals</a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -256,8 +256,8 @@ in_use:
                         <div class="con-program">
                             <p>San Diego, California</p>
                         </div>
-                        <a class="con-button" href="https://events.linuxfoundation.org/jupytercon/"><button>Conference Website</button></a>
-                        <a class="con-button" href="https://events.linuxfoundation.org/jupytercon/program/cfp/"><button>Call for Proposals</button></a>
+                        <button class="con-button"><a href="https://events.linuxfoundation.org/jupytercon/">Conference Website</a></button>
+                        <button class="con-button"><a href="https://events.linuxfoundation.org/jupytercon/program/cfp/">Call for Proposals</a></button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This fixes a failing CI due to a rule that we can't nest a button inside of an `a` element. It also adds two ignore rules for links that were returning errors even though they were valid (and these are common / stable links so I think it's safe to ignore them).