### PR TITLE
Use JupyterLite for the R demo

### DIFF
--- a/try.html
+++ b/try.html
@@ -79,8 +79,8 @@ kernel_boxes:
     - title: R
       description: How to use Jupyter with R
       src: try/R.svg
-      alt: R logo - Launch R demo Binder
-      url: https://mybinder.org/v2/gh/binder-examples/r/HEAD?filepath=index.ipynb
+      alt: R logo - Launch R demo
+      url: https://jupyter.org/try-jupyter/lab/index.html?path=notebooks%2Fr.ipynb
 
     - title: Ruby
       description: How to use Jupyter with Ruby


### PR DESCRIPTION
As discussed in https://github.com/jupyter/try-jupyter/pull/60 with @choldgraf, if the Jupyterlite can help reduce the load on [mybinder.org](https://mybinder.org/) maybe it could be useful to point users to that static deployment.

Especially since the demo notebook used for the current demo seems to be fully working in the browser.

Link to test: https://deploy-preview-801--jupyter-github-io.netlify.app/

https://github.com/user-attachments/assets/7ce89dad-d862-4799-a497-1c0f802a02c6


