### PR TITLE
Update email to report the security vulnerabilities

### DIFF
--- a/security.md
+++ b/security.md
@@ -11,11 +11,11 @@ of security issues.
 
 ## How to report vulnerabilities
 
-If you believe you've found a security vulnerability in a [Jupyter Subproject](https://jupyter.org/governance/list_of_subprojects.html),
-you can either:
+To report a security vulnerability in a [Jupyter Subproject](https://jupyter.org/governance/list_of_subprojects.html),
+take one of these two actions:
 
- - directly open a GitHub Security Advisory (GHSA) in the relevant repository (this is the preferred approach)
- - report it to [security@jupyter.org](mailto:security@jupyter.org) if opening a GHSA is not possible, or you are unsure
+ 1. **Open a GitHub Security Advisory** (GHSA) in the relevant repository (preferred approach). See [the GitHub instructions for opening security advisories](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).
+ 2. **Send an e-mail to [security@jupyter.org](mailto:security@jupyter.org)** reporting the vulnerability. Only do this if opening a GHSA is not possible, or you are unsure what to do.
    where it will belong.
 
 **We do not currently run bug bounty programs, and do not currently reward

--- a/security.md
+++ b/security.md
@@ -14,8 +14,8 @@ of security issues.
 If you believe you've found a security vulnerability in a [Jupyter Subproject](https://jupyter.org/governance/list_of_subprojects.html),
 you can either:
 
- - directly open a GitHub Security Advisory (GHSA) in the relevant repository
- - report it to [security@ipython.org](mailto:security@ipython.org) if opening a GHSA is not possible, or you are unsure
+ - directly open a GitHub Security Advisory (GHSA) in the relevant repository (this is the preferred approach)
+ - report it to [security@jupyter.org](mailto:security@jupyter.org) if opening a GHSA is not possible, or you are unsure
    where it will belong.
 
 **We do not currently run bug bounty programs, and do not currently reward


### PR DESCRIPTION
Also mention that private vulnerability reports via GHSA are the preferred approach.

References:
- https://github.com/jupyter/security/issues/111
- https://github.com/jupyter/security/issues/73
- Executive council office hours notes for [Jun 12 2025](https://docs.google.com/document/d/1N5jm0VJlDUX4WK0n7Ia8Ff63RdzNYkH28PkSZPdBtUc/edit?tab=t.0#heading=h.8goqcpbrxnzu)