### PR TITLE
Replace <p> inside <a> with <span> and <small> for valid HTML

### DIFF
--- a/widgets.html
+++ b/widgets.html
@@ -33,62 +33,62 @@ permalink: /widgets
       <ul id="widgetTabs" class="nav nav-tabs" role="tablist">
         <li class="nav-item">
           <a href="#ipyleaflet" class="active" data-bs-toggle="tab">
-          <p>ipyleaflet</p>
-          <p>Geo-spatial analytics</p>
+          <span>ipyleaflet</span>
+          <small>Geo-spatial analytics</small>
           </a>
         </li>
         <li class="nav-item">
           <a href="#bqplot" data-bs-toggle="tab">
-            <p>bqplot</p>
-            <p>2-D interactive data visualization</p>
+            <span>bqplot</span>
+            <small>2-D interactive data visualization</small>
           </a>
         </li>
         <li class="nav-item">
           <a href="#pythreejs" data-bs-toggle="tab">
-            <p>pythreejs</p>
-            <p>3-D data visualization</p>
+            <span>pythreejs</span>
+            <small>3-D data visualization</small>
           </a>
         </li>
         <li class="nav-item">
           <a href="#ipyvolume" data-bs-toggle="tab">
-            <p>ipyvolume</p>
-            <p>3-D plotting</p>
+            <span>ipyvolume</span>
+            <small>3-D plotting</small>
           </a>
         </li>
         <li class="nav-item">
           <a href="#nglview" data-bs-toggle="tab">
-            <p>nglview</p>
-            <p>3-D interactive molecular visualization</p>
+            <span>nglview</span>
+            <small>3-D interactive molecular visualization</small>
           </a>
         </li>
         <li class="nav-item">
           <a href="#k3d" data-bs-toggle="tab" onclick="adjustK3D()">
-            <p>K3D-Jupyter</p>
-            <p>3-D data visualization</p>
+            <span>K3D-Jupyter</span>
+            <small>3-D data visualization</small>
           </a>
         </li>
         <li class="nav-item">
           <a href="#beakerx" data-bs-toggle="tab" onclick="adjustBeakerXTable()">
-            <p>BeakerX</p>
-            <p>tables, plotting, forms</p>
+            <span>BeakerX</span>
+            <small>tables, plotting, forms</small>
           </a>
         </li>
         <li class="nav-item">
           <a href="#jupyter-gmaps" data-bs-toggle="tab">
-            <p>jupyter-gmaps</p>
-            <p>Data visualization on Google Maps</p>
+            <span>jupyter-gmaps</span>
+            <small>Data visualization on Google Maps</small>
           </a>
         </li>
         <li class="nav-item">
           <a href="#cookiecutter" data-bs-toggle="tab">
-            <p>cookiecutter</p>
-            <p>Template widget project</p>
+            <span>cookiecutter</span>
+            <small>Template widget project</small>
           </a>
         </li>
         <li class="nav-item">
           <a href="#perspective" data-bs-toggle="tab">
-            <p>perspective</p>
-            <p>Real-time Dataset Visualization</p>
+            <span>perspective</span>
+            <small>Real-time Dataset Visualization</small>
           </a>
         </li>
       </ul>


### PR DESCRIPTION
HTML does not allow a <p> tag directly inside an <a> tag. This change replaces <p> with <span> and <small> elements to maintain semantic structure and ensure valid, accessible HTML.
