### PR TITLE
Linkify links on the social page

### DIFF
--- a/social.md
+++ b/social.md
@@ -20,17 +20,17 @@ If you are organizing a Jupyter event or have something Jupyter-related that sho
 
 List of channels actively maintained by JMS in alphabetical order:
 
-- Bluesky: https://bsky.app/profile/jupyter.org
-- Discourse: https://discourse.jupyter.org
-- LinkedIn: https://linkedin.com/company/project-jupyter
-- Medium: https://blog.jupyter.org
-- Mastodon:  https://hachyderm.io/@ProjectJupyter
-- Slack JupyterLab: https://jupyterlabworkspace.slack.com
-- YouTube: https://youtube.com/@projectjupyter
-- Zulip: https://jupyter.zulipchat.com
+- Bluesky: <https://bsky.app/profile/jupyter.org>
+- Discourse: <https://discourse.jupyter.org>
+- LinkedIn: <https://linkedin.com/company/project-jupyter>
+- Medium: <https://blog.jupyter.org>
+- Mastodon:  <https://hachyderm.io/@ProjectJupyter>
+- Slack JupyterLab: <https://jupyterlabworkspace.slack.com>
+- YouTube: <https://youtube.com/@projectjupyter>
+- Zulip: <https://jupyter.zulipchat.com>
 
 
 List of channels considered inactive but managed by the JMS:
 
-- Facebook: https://facebook.com/projectjupyter
-- Slack JupyterCon 2023: https://jupyterconworkspace.slack.com
+- Facebook: <https://facebook.com/projectjupyter>
+- Slack JupyterCon 2023: <https://jupyterconworkspace.slack.com>


### PR DESCRIPTION
Just realized that the link addresses are not actual links. This syntax should fix this.