### PR TITLE
Use JupyterLite for the C++ demo

### DIFF
--- a/try.html
+++ b/try.html
@@ -55,8 +55,8 @@ kernel_boxes:
     - title: C++
       description: How to use Jupyter with C++
       src: try/Cpp.svg
-      alt: C++ logo - Launch C++ demo Binder
-      url: https://mybinder.org/v2/gh/jupyter-xeus/xeus-cling/stable?filepath=notebooks/xcpp.ipynb
+      alt: C++ logo - Launch C++ demo
+      url: https://jupyter.org/try-jupyter/lab/index.html?path=notebooks%2Fcpp.ipynb
 
     - title: Julia
       description: How to use Jupyter with Julia


### PR DESCRIPTION
Similar to https://github.com/jupyter/jupyter.github.io/pull/801 but for the C++ demo.

If I remember correctly the C++ demo was one of the most launched demos on Binder. So hopefully this will also help save resources on https://mybinder.org.

Thanks to @anutosh491 for the great work on xeus-cpp!

https://github.com/user-attachments/assets/db9b51ad-58e3-4ac5-8227-a09ead03e754


