### PR TITLE
Ignore the link check of cvedetails.com, since we are getting 403

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -94,7 +94,8 @@ jobs:
            --check-links-ignore "https://www.bloomberg.com" \
            --check-links-ignore "https://www.oracle.com" \
            --check-links-ignore "https://stackoverflow.com" \
-           --check-links-ignore "https://opensource.org/licenses/BSD-3-Clause"
+           --check-links-ignore "https://opensource.org/licenses/BSD-3-Clause" \
+           --check-links-ignore "https://www.cvedetails.com/vulnerability-list/vendor_id-15653/Jupyter.html"
 
   lighthouse:
 


### PR DESCRIPTION
We get a 403 when running the link check and trying to visit this URL.

```
=================================== FAILURES ===================================
_ /home/runner/work/jupyter.github.io/jupyter.github.io/_site/security.html: https://www.cvedetails.com/vulnerability-list/vendor_id-15653/Jupyter.html _
https://www.cvedetails.com/vulnerability-list/vendor_id-15653/Jupyter.html: 403: Forbidden
=============================== warnings summary ===============================
../../../.local/lib/python3.12/site-packages/jupyter_client/connect.py:22
  /home/runner/.local/lib/python3.12/site-packages/jupyter_client/connect.py:22: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write

../../../.local/lib/python3.12/site-packages/_pytest/cacheprovider.py:475
  /home/runner/.local/lib/python3.12/site-packages/_pytest/cacheprovider.py:475: PytestCacheWarning: could not create cache path /.pytest_cache/v/cache/nodeids: [Errno 13] Permission denied: '/pytest-cache-files-p1xdd79b'
    config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

../../../.local/lib/python3.12/site-packages/_pytest/cacheprovider.py:429
  /home/runner/.local/lib/python3.12/site-packages/_pytest/cacheprovider.py:429: PytestCacheWarning: could not create cache path /.pytest_cache/v/cache/lastfailed: [Errno 13] Permission denied: '/pytest-cache-files-y0vyvqe1'
    config.cache.set("cache/lastfailed", self.lastfailed)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED _site/security.html::/home/runner/work/jupyter.github.io/jupyter.github.io/_site/security.html <a href=https://www.cvedetails.com/vulnerability-list/vendor_id-15653/Jupyter.html>
============ 1 failed, 426 passed, 3 warnings in 112.00s (0:01:52) =============
```