### PR TITLE
Remove ipywidgets link from the Applications section (Lab, Notebook, Voilà)

### DIFF
--- a/try.html
+++ b/try.html
@@ -39,12 +39,6 @@ application_boxes:
       alt: Python logo - Launch Jupyter Notebook demo
       url: https://jupyter.org/try-jupyter/notebooks/?path=notebooks/Intro.ipynb
 
-    - title: Jupyter Widgets
-      description: HTML widgets in Jupyter notebooks for interactive exploration of input data
-      src: try/jupyter.png
-      alt: JupyterLite logo - Launch Jupyter Widgets demo
-      url: https://ipywidgets.rtfd.io/en/latest/try/lab/index.html?path=Widget%20List.ipynb
-
     - title: Voilà
       description: Share insights by converting notebooks into interactive dashboards
       src: try/voila.svg


### PR DESCRIPTION
I just noticed we had a link to a specific ipywidgets example in try-jupyter, which seems out of place as it is listed in the "applications" section (such as Notebook, JupyterLab, or Voilà).

Proposing to remove it for clarity.