### PR TITLE
Add JupyterCon banner to all pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -135,35 +135,6 @@ legal:
             </div>
         </div>
     </div>
-    <div class="jumbotron">
-      <div class="col-md-12">
-          {% for img in page.jumbotron.images %}
-          <div class="jumbotron-image-container">
-              <span>
-                  <img class="img-responsive {{ img.class }}"
-                        src="/assets/homepage/{{ img.src }}"
-                        width={{ img.width }}
-                        height={{ img.height }}
-                        alt="{{ img.alt }}"
-                        loading="eager" />
-              </span>
-          </div>
-          {% endfor %}
-          <img class="img-responsive"
-                src="/assets/homepage/{{ page.jumbotron.background }}"
-                width=747
-                height=313
-                alt="white background"
-                loading="eager" />
-      </div>
-    </div>
-    <div class="container">
-      <div class="col-md-12">
-          <div class="col-md-8 col-md-offset-2">
-          <div class="jumbotron-text">{{ page.jumbotron.text }}</div>
-          </div>
-      </div>
-    </div>
 </header>
     <section>
       {{ content }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -122,7 +122,10 @@ legal:
                 <div class="con-container img-responsive">
                     <div class="col-lg-8 con-content md-offset-2">
                         <a href="https://events.linuxfoundation.org/jupytercon/"><img class="con-title img-responsive" src="assets/JupyterCon-Logo-white.svg" alt="The JupyterCon Logo" /></a>
-                        <div class="con-date">November 4-5, 2025; Tutorials November 3, Sprints November 6</div>
+                        <div class="con-date">November 4-5, 2025</div>
+                        <div class="con-program">
+                            <p>Tutorials Nov 3, Sprints Nov 6</p>
+                        </div>
                         <div class="con-program">
                             <p>San Diego, California</p>
                         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -122,7 +122,7 @@ legal:
                 <div class="con-container img-responsive">
                     <div class="col-lg-8 con-content md-offset-2">
                         <a href="https://events.linuxfoundation.org/jupytercon/"><img class="con-title img-responsive" src="assets/JupyterCon-Logo-white.svg" alt="The JupyterCon Logo" /></a>
-                        <div class="con-date">November 04-05, 2025</div>
+                        <div class="con-date">November 4-5, 2025; Tutorials November 3, Sprints November 6</div>
                         <div class="con-program">
                             <p>San Diego, California</p>
                         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -115,6 +115,56 @@ legal:
             </ul>
         </div>
     </nav>
+    <header>
+      <div class="jumbotron con-jumbotron">
+        <div class="row">
+            <div class="col-md-12" style='padding:0'>
+                <div class="con-container img-responsive">
+                    <div class="col-lg-8 con-content md-offset-2">
+                        <a href="https://events.linuxfoundation.org/jupytercon/"><img class="con-title img-responsive" src="assets/JupyterCon-Logo-white.svg" alt="The JupyterCon Logo" /></a>
+                        <div class="con-date">November 04-05, 2025</div>
+                        <div class="con-program">
+                            <p>San Diego, California</p>
+                        </div>
+                        <div class="con-buttons">
+                          <a class="con-button" role="button" href="https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=a3a6fcc4-957d-4870-8826-daca933856ce/" target="_blank">Register</a>
+                          <a class="con-button" role="button" href="https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=a3a6fcc4-957d-4870-8826-daca933856ce" target="_blank">View Schedule</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="jumbotron">
+      <div class="col-md-12">
+          {% for img in page.jumbotron.images %}
+          <div class="jumbotron-image-container">
+              <span>
+                  <img class="img-responsive {{ img.class }}"
+                        src="/assets/homepage/{{ img.src }}"
+                        width={{ img.width }}
+                        height={{ img.height }}
+                        alt="{{ img.alt }}"
+                        loading="eager" />
+              </span>
+          </div>
+          {% endfor %}
+          <img class="img-responsive"
+                src="/assets/homepage/{{ page.jumbotron.background }}"
+                width=747
+                height=313
+                alt="white background"
+                loading="eager" />
+      </div>
+    </div>
+    <div class="container">
+      <div class="col-md-12">
+          <div class="col-md-8 col-md-offset-2">
+          <div class="jumbotron-text">{{ page.jumbotron.text }}</div>
+          </div>
+      </div>
+    </div>
+</header>
     <section>
       {{ content }}
     </section>

--- a/index.html
+++ b/index.html
@@ -246,25 +246,6 @@ in_use:
 ---
 
 <header>
-      <div class="jumbotron con-jumbotron">
-        <div class="row">
-            <div class="col-md-12" style='padding:0'>
-                <div class="con-container img-responsive">
-                    <div class="col-lg-8 con-content md-offset-2">
-                        <a href="https://events.linuxfoundation.org/jupytercon/"><img class="con-title img-responsive" src="assets/JupyterCon-Logo-white.svg" alt="The JupyterCon Logo" /></a>
-                        <div class="con-date">November 04-05, 2025</div>
-                        <div class="con-program">
-                            <p>San Diego, California</p>
-                        </div>
-                        <div class="con-buttons">
-                          <a class="con-button" role="button" href="https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=a3a6fcc4-957d-4870-8826-daca933856ce/" target="_blank">Register</a>
-                          <a class="con-button" role="button" href="https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=a3a6fcc4-957d-4870-8826-daca933856ce" target="_blank">View Schedule</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
     <div class="jumbotron">
       <div class="col-md-12">
           {% for img in page.jumbotron.images %}


### PR DESCRIPTION
This attempts to add the JupyterCon banner to all pages of jupyter.org, not just the homepage.

I also added the tutorial and sprint dates, because in the past there has been a lot of confusion about extra days outside of the main days. Like people wanted to come to the sprints, but didn't know about them until after they had bought flights.