### PR TITLE
Removed ajs_aid parameters

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -132,8 +132,8 @@ legal:
                             <p>San Diego, California</p>
                         </div>
                         <div class="con-buttons">
-                          <a class="con-button" role="button" href="https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=a3a6fcc4-957d-4870-8826-daca933856ce/" target="_blank">Register</a>
-                          <a class="con-button" role="button" href="https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=a3a6fcc4-957d-4870-8826-daca933856ce" target="_blank">View Schedule</a>
+                          <a class="con-button" role="button" href="https://events.linuxfoundation.org/jupytercon/register/" target="_blank">Register</a>
+                          <a class="con-button" role="button" href="https://events.linuxfoundation.org/jupytercon/program/schedule/" target="_blank">View Schedule</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
* Removed ajs_aid parameters from Jupytercon register and view schedule buttons.

Per LF Marketing:

> ...Because of this, we have observed hundreds, even thousands, of users coming to the events website (great!), but all that web traffic is resolving to a single user. This has a negative impact on the marketing team's ability to track users from advertising spend to visiting your website to ultimately making a purchase on the events website.
