### PR TITLE
Change Rick Wagner's affiliation to Argonne

### DIFF
--- a/about.html
+++ b/about.html
@@ -44,7 +44,6 @@ distinguished_2024:
   - name: Rick Wagner
     photo: Rick_Wagner.jpg
     gh_handle: rpwagner
-    linkedin: https://www.linkedin.com/in/rpwagner/
 
 distinguished_2023:
   - name: Nicolas Brichet
@@ -404,8 +403,7 @@ executive_council:
     linkedin: https://linkedin.com/in/zach-sailer-8a1472151/
   - name: Rick Wagner
     photo: RickWagner.jpg
-    affiliation: UC San Diego
-    linkedin: https://www.linkedin.com/in/rpwagner
+    affiliation: Argonne Leadership Computing Facility
     gh_handle: rpwagner
 
 software_steering_council:


### PR DESCRIPTION
Updated Rick Wagner's affiliation and removed LinkedIn link.