### PR TITLE
Update trademark committee membership

### DIFF
--- a/about.html
+++ b/about.html
@@ -523,7 +523,7 @@ community_building:
   affiliation: Anaconda
   gh_handle: RRosio
 - name: April Johnson 
-  photo: April_Johnson.jpeg
+  photo: April_Johnson.jpg
   affiliation: 2i2c
   gh_handle: aprilmj
   linkedin: https://www.linkedin.com/in/apriljohnson


### PR DESCRIPTION
Near the beginning of the year we had a membership checkin for the trademark group. This updates the membership list to align with the results. Thank you @ellisonbg and @tgeorgeux for your service!

Bonus fix: April's photo had a typo in the name, so it wasn't showing on the website. Fixed that too.
