### PR TITLE
Standardize the JupyterLite links in /try

### DIFF
--- a/try.html
+++ b/try.html
@@ -31,7 +31,7 @@ application_boxes:
       description: The latest web-based interactive development environment
       src: try/jupyter.png
       alt: Jupyter logo - Launch JupyterLab demo
-      url: https://jupyter.org/try-jupyter/lab?path=notebooks%2FIntro.ipynb
+      url: https://jupyter.org/try-jupyter/lab/?path=notebooks%2FIntro.ipynb
 
     - title: Jupyter Notebook
       description: The original web application for creating and sharing computational documents
@@ -50,7 +50,7 @@ kernel_boxes:
       description: How to use Jupyter with C++
       src: try/Cpp.svg
       alt: C++ logo - Launch C++ demo
-      url: https://jupyter.org/try-jupyter/lab/index.html?path=notebooks%2Fcpp.ipynb
+      url: https://jupyter.org/try-jupyter/lab/?path=notebooks%2Fcpp.ipynb
 
     - title: Julia
       description: How to use Jupyter with Julia
@@ -68,7 +68,7 @@ kernel_boxes:
       description: How to use Jupyter with R
       src: try/R.svg
       alt: R logo - Launch R demo
-      url: https://jupyter.org/try-jupyter/lab/index.html?path=notebooks%2Fr.ipynb
+      url: https://jupyter.org/try-jupyter/lab/?path=notebooks%2Fr.ipynb
 
     - title: Ruby
       description: How to use Jupyter with Ruby


### PR DESCRIPTION
Currently the plausible stats for JupyterLite count both links separately, even though one redirects to the other. This hopefully will consolidate the usage stats.

The stats for `/try-jupyter` (i.e., JupyterLite) are [here](https://plausible.io/jupyter.org?f=is,segment,4524&l=segment-4524,JupyterLite&period=day&keybindHint=E&date=2026-01-12), and you can see plausible is tracking, for example, the `/try-jupyter/lab/` url separate from the `/try-jupyter/lab/index.html` url.

<img width="530" height="424" alt="image" src="https://github.com/user-attachments/assets/ed733595-0c53-4ce0-aaff-6902ce5168db" />
