### PR TITLE
Fix broken homepage mobile layout by preventing horizontal overflow

### DIFF
--- a/_sass/components/_homepage.scss
+++ b/_sass/components/_homepage.scss
@@ -72,6 +72,10 @@
     justify-content: start;
     align-items: center;
     flex-direction: row;
+    @media (min-width: 421px) and (max-width: 991px) {
+      align-items: start;
+      flex-wrap: wrap;
+    }
     @media (max-width: $breakpoint-s) {
       margin-top: 1em;
       align-items: start;
@@ -79,6 +83,12 @@
     }
     .feature {
       margin: 0 2em;
+      @media (min-width: 421px) and (max-width: 991px) {
+        box-sizing: border-box;
+        margin: 0 0 2em 0;
+        padding: 0 1em;
+        width: 50%;
+      }
       @media (max-width: $breakpoint-s) {
         margin: 0 0 2em 0;
       }


### PR DESCRIPTION
## Summary
On the homepage, the Notebook feature section overflows horizontally at certain viewport widths between `421px` and `991px`, creating page-wide horizontal scrolling that breaks the page layout and compresses text into very narrow columns (sometimes just 1–2 words per line) that are difficult to read. This fix contains overflow in that range by wrapping feature cards into a two-column layout while preserving existing behavior below `421px` and at `992px+`.

Why this approach?
- This was the simplest, lowest-risk fix: a targeted, scoped CSS media query for the affected range, with no template/HTML changes.
- It avoids reworking existing global breakpoint values, like expanding the `<=420px` behaviors which would collapse the layout earlier than intended and introduce unnecessary whitespace.
- It looks polished and fits the visual intent of the page.

What changed:
- Added a media query for `@media (min-width: 421px) and (max-width: 991px)` in `_sass/components/_homepage.scss` for `.homepage-section .featurelist` to enable wrapping.
- Updated `.feature` cards in that same range to fit two per row (`width: 50%`) with controlled spacing (`margin`, `padding`) and `box-sizing: border-box` to prevent overflow.
- Kept existing small-screen behavior (`<=420px` stacks vertically) and desktop behavior (`>=992px`) intact.


## Before and After Screenshots
**Mobile captures from a device with an approximately 450px viewport width**

### Before
*Notice text content collapsing to 1-2 words per line, and the image underneath the feature section has empty whitespace to the right of it indicating page overflow*
<img width="400" height="823" alt="jupyter-BEFORE" src="https://github.com/user-attachments/assets/82c3c93c-8f76-44cd-aa0b-2a78707d7a56" />
<br /><br />

### After
*Notice all columns fit more than 2 words per line and the image under the feature section now has margins equal to the rest of the page indicating no page overflow** 
<img width="400" height="823" alt="jupyter-AFTER" src="https://github.com/user-attachments/assets/21cddde2-004d-4737-bc95-6ff5fd42f45d" />
