### PR TITLE
Update website to direct security reports to security@jupyter.org

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,5 +1,5 @@
 # Our security address
-Contact: mailto:security@ipython.org
+Contact: mailto:security@jupyter.org
 
 # Our OpenPGP key
 Encryption: https://jupyter.org/assets/ipython_security.asc

--- a/security.md
+++ b/security.md
@@ -34,7 +34,7 @@ If you prefer to encrypt your security reports, use [this PGP public key](assets
      - You ran a tool and think there is vulnerability because you are learning. In the body of your message, include your analysis and your uncertainty about the problem.
      - You are a security researcher: Verify the tool claim and try to develop
        a POC showing how the vulnerability could be exploited, and the fix that could resolve the problem.
-- **Avoid** sending mass emails to `security@ipython.org` (especially when cc'ing dozens of other emails from bug bounty programs)
+- **Avoid** sending mass emails to `security@jupyter.org` (especially when cc'ing dozens of other emails from bug bounty programs)
 - **Avoid** asking if we run a bug bounty programs or reward discovery in a private channel, discuss it in the public forum.
 
 


### PR DESCRIPTION
This aligns with the directions at the top of jupyter.org/security
