### PR TITLE
Simplify community channel list

### DIFF
--- a/_includes/community-resource.html
+++ b/_includes/community-resource.html
@@ -7,5 +7,8 @@
         <h3 class="resource-name"><a href="{{ include.url }}">{{ include.title }}</a></h3>
         <p class="resource-desc">{{ include.description }}</p>
       </div>
+      <div class="col-md-2 resource-button">
+        <a href="{{ include.url }}">View</a>
+      </div>
     </div>
   </div>

--- a/_includes/community-resource.html
+++ b/_includes/community-resource.html
@@ -1,14 +1,11 @@
   <div class="resource col-sm-6 col-md-12">
     <div class="resource-content">
       <div class="col-md-2">
-        <img src="{{ include.src }}" class="resource-logo" alt="{{ include.alt }}">
+        <a href="{{ include.url }}"><img src="{{ include.src }}" class="resource-logo" alt="{{ include.alt }}"></a>
       </div>
       <div class="col-md-8 resource-text">
-        <h3 class="resource-name">{{ include.title }}</h3>
+        <h3 class="resource-name"><a href="{{ include.url }}">{{ include.title }}</a></h3>
         <p class="resource-desc">{{ include.description }}</p>
-      </div>
-      <div class="col-md-2 resource-button">
-        <a href="{{ include.url }}">View</a>
       </div>
     </div>
   </div>

--- a/_sass/components/_community-resource.scss
+++ b/_sass/components/_community-resource.scss
@@ -25,6 +25,25 @@
   .resource-name {
     margin-top: 6px;
   }
+  .resource-button {
+    margin-top: 32px;
+    text-align: center;
+    a {
+      background-color: $button-orange;
+      border-radius: 2px;
+      color: white;
+      letter-spacing: 1px;
+      padding: 13px;
+      text-decoration: none;
+      -webkit-transition: 0.2s;
+      &:hover {
+        background-color: $button-hover;
+      }
+      &:active {
+        background-color: $button-active;
+      }
+    }
+  }
 }
 
 @media (max-width: $breakpoint-l) {

--- a/_sass/components/_community-resource.scss
+++ b/_sass/components/_community-resource.scss
@@ -25,25 +25,6 @@
   .resource-name {
     margin-top: 6px;
   }
-  .resource-button {
-    margin-top: 32px;
-    text-align: center;
-  }
-  a {
-    background-color: $button-orange;
-    border-radius: 2px;
-    color: white;
-    letter-spacing: 1px;
-    padding: 13px;
-    text-decoration: none;
-    -webkit-transition: 0.2s;
-    &:hover {
-      background-color: $button-hover;
-    }
-    &:active {
-      background-color: $button-active;
-    }
-  }
 }
 
 @media (max-width: $breakpoint-l) {


### PR DESCRIPTION
Make the headings and icons clickable to go to the site. I also tried out not having the View buttons, but then it wasn't really really clear how to get to the channel, so I put them back in as well.

<img width="713" height="598" alt="image" src="https://github.com/user-attachments/assets/19434940-0b97-4975-8cd4-c9812faa0175" />
