### PR TITLE
Revert "Jupyter User Survey banner"

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -151,11 +151,6 @@ legal:
             </ul>
         </div>
     </nav>
-    <div class="survey-banner">
-      <p>
-        <a href="https://linuxfoundation.surveymonkey.com/r/jupyter-user-survey" target="_blank" rel="noopener noreferrer">Take the short Jupyter User Survey</a> to give feedback on how to improve Jupyter.
-      </p>
-    </div>
     <section>
       {{ content }}
     </section>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -24,30 +24,6 @@
 @import "components/hr";
 @import "components/details";
 
-/* Styling for the call-to-survey banner */
-.survey-banner {
-    background-color: $orange;
-    color: $white;
-    text-align: center;
-    padding: 0.6em 1em;
-}
-
-.survey-banner p {
-    margin: 0;
-}
-
-.survey-banner a {
-    color: $white;
-    text-decoration: underline;
-    text-decoration-thickness: 2px;
-}
-
-.survey-banner a:hover,
-.survey-banner a:focus,
-.survey-banner a:active {
-    color: $white;
-}
-
 .dropshadow {
     /* Make the foreground stand out from the background slightly */
     filter: drop-shadow(0px 0px 8px rgba(0,0,0,0.3));


### PR DESCRIPTION
Reverts jupyter/jupyter.github.io#854 (adding the Jupyter User Survey banner) since the user survey is now closed.

From Plausible, it looks like we had about [5400 clicks](https://plausible.io/jupyter.org?f=is,goal,Outbound%20Link:%20Click&f=is,props:url,https://linuxfoundation.surveymonkey.com/r/jupyter-user-survey) on the banner, which is a 0.9% conversion rate.