### PR TITLE
Add a banner system and a banner for the Jupyter Foundation cfp

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,10 +20,14 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build the site in the Jekyll/builder container
+      # Newer jekyll/builder images no longer run `bundle install`
+      # automatically, so install the Gemfile's gems (github-pages etc.)
+      # explicitly and build with `bundle exec` so the pinned Jekyll version
+      # is used instead of the image's own.
       run: |
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        jekyll/builder:latest /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"
+        jekyll/builder:latest /bin/bash -c "chmod -R 777 /srv/jekyll && cd /srv/jekyll && bundle install && bundle exec jekyll build --future"
 
     - name: List result of Jekyll build
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,6 +62,8 @@ jobs:
       with:
         root: _site/
         skip_git_check: true
+        # banner.html is an HTML fragment so it can be fetched and included in a page
+        blacklist: banner.html
 
   check-links:
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,51 @@ Here's an image of this box on a GitHub PR page:
 
 ![Netlify Preview Button](.github/images/netlify-preview.png)
 
+## Site-wide announcement banner
+
+The file [`assets/banner.html`](assets/banner.html) controls an announcement
+banner that is shown at the top of jupyter.org **and** at the top of Jupyter
+documentation sites that subscribe to it (see below). It is served at
+<https://jupyter.org/assets/banner.html>.
+
+- **To show a banner**: open a PR that puts a short HTML fragment in
+  `assets/banner.html`, for example:
+
+  ```html
+  <p>
+    <a href="https://example.org/survey" target="_blank" rel="noopener noreferrer">
+      Take the short Jupyter User Survey
+    </a> to give feedback on how to improve Jupyter.
+  </p>
+  ```
+
+- **To remove the banner**: open a PR that empties `assets/banner.html`
+  (the file must be completely empty — even an HTML comment counts as content
+  and would show an empty banner on documentation sites).
+
+Notes:
+
+- Keep the fragment to plain content (text and links). Each site provides its
+  own banner container and styling: jupyter.org styles it with the
+  `.global-banner` component, and documentation sites style it with their
+  theme's announcement banner.
+- Changes take effect on jupyter.org when the site is rebuilt (a few minutes
+  after merging), and on documentation sites at the next page load — no
+  documentation rebuilds are needed, and previously published documentation
+  versions pick up the change too.
+
+### Subscribing a documentation site to the banner
+
+Documentation sites using the pydata-sphinx-theme, which has an [announcements](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/announcements.html) feature, can subscribe by including the following code in their `conf.py`:
+
+```python
+html_theme_options = {
+    # Default: show the shared Jupyter announcement banner; content is managed
+    # at https://github.com/jupyter/jupyter.github.io (assets/banner.html).
+    "announcement": "https://jupyter.org/assets/banner.html",
+}
+```
+
 ## Web analytics (experimental)
 
 We are experimenting with [Plausible.io](https://plausible.io/) for web analytics.

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ Here's an image of this box on a GitHub PR page:
 
 ## Site-wide announcement banner
 
-The file [`assets/banner.html`](assets/banner.html) controls an announcement
-banner that is shown at the top of jupyter.org **and** at the top of Jupyter
-documentation sites that subscribe to it (see below). It is served at
-<https://jupyter.org/assets/banner.html>.
+The file [`_includes/banner.html`](_includes/banner.html) controls an
+announcement banner that is shown at the top of jupyter.org **and** at the top
+of Jupyter documentation sites that subscribe to it (see below). At build time
+the content is embedded into every jupyter.org page and also published at
+<https://jupyter.org/assets/banner.html> for documentation sites.
 
 - **To show a banner**: open a PR that puts a short HTML fragment in
-  `assets/banner.html`, for example:
+  `_includes/banner.html`, for example:
 
   ```html
   <p>
@@ -36,9 +37,8 @@ documentation sites that subscribe to it (see below). It is served at
   </p>
   ```
 
-- **To remove the banner**: open a PR that empties `assets/banner.html`
-  (the file must be completely empty — even an HTML comment counts as content
-  and would show an empty banner on documentation sites).
+- **To remove the banner**: open a PR that empties `_includes/banner.html`
+  (empty the file, but do not delete it — the site build references it).
 
 Notes:
 
@@ -46,10 +46,6 @@ Notes:
   own banner container and styling: jupyter.org styles it with the
   `.global-banner` component, and documentation sites style it with their
   theme's announcement banner.
-- Changes take effect on jupyter.org when the site is rebuilt (a few minutes
-  after merging), and on documentation sites at the next page load — no
-  documentation rebuilds are needed, and previously published documentation
-  versions pick up the change too.
 
 ### Subscribing a documentation site to the banner
 

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,0 +1,6 @@
+  <p>
+    The Jupyter Foundation <a href="https://blog.jupyter.org/2026-jupyter-community-call-for-funding-proposals-f938928a1b8e">call for funding proposals</a> is now open.
+    <a href="https://jupyterfoundation.org/community-funding-proposals/submit-a-proposal/">
+      Submit a proposal
+    </a> for improving Jupyter.
+  </p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -151,6 +151,23 @@ legal:
             </ul>
         </div>
     </nav>
+    <!-- Site-wide announcement banner. The content is loaded from
+         /assets/banner.html; leave that file empty to show no banner.
+         The same file feeds the announcement banner on Jupyter documentation
+         sites. See the "Site-wide announcement banner" section in README.md. -->
+    <div id="global-banner" class="global-banner" hidden></div>
+    <script>
+      fetch('/assets/banner.html')
+        .then(function (response) { return response.ok ? response.text() : ''; })
+        .then(function (html) {
+          html = html.trim();
+          if (!html) { return; }
+          var banner = document.getElementById('global-banner');
+          banner.innerHTML = html;
+          banner.hidden = false;
+        })
+        .catch(function () { /* no banner on error */ });
+    </script>
     <section>
       {{ content }}
     </section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -151,23 +151,16 @@ legal:
             </ul>
         </div>
     </nav>
-    <!-- Site-wide announcement banner. The content is loaded from
-         /assets/banner.html; leave that file empty to show no banner.
-         The same file feeds the announcement banner on Jupyter documentation
-         sites. See the "Site-wide announcement banner" section in README.md. -->
-    <div id="global-banner" class="global-banner" hidden></div>
-    <script>
-      fetch('/assets/banner.html')
-        .then(function (response) { return response.ok ? response.text() : ''; })
-        .then(function (html) {
-          html = html.trim();
-          if (!html) { return; }
-          var banner = document.getElementById('global-banner');
-          banner.innerHTML = html;
-          banner.hidden = false;
-        })
-        .catch(function () { /* no banner on error */ });
-    </script>
+    <!-- Site-wide announcement banner. The content lives in
+         _includes/banner.html; leave that file empty to show no banner.
+         The same content feeds the announcement banner on Jupyter
+         documentation sites, via /assets/banner.html. See the "Site-wide
+         announcement banner" section in README.md. -->
+    {%- capture banner_content %}{% include banner.html %}{% endcapture %}
+    {%- assign banner_content = banner_content | strip %}
+    {%- if banner_content != "" %}
+    <div id="global-banner" class="global-banner">{{ banner_content }}</div>
+    {%- endif %}
     <section>
       {{ content }}
     </section>

--- a/_sass/components/_banner.scss
+++ b/_sass/components/_banner.scss
@@ -18,7 +18,8 @@
         margin: 0;
     }
 
-    a {
+    a, a:hover, a:focus {
+        opacity: 1;
         color: $white;
         text-decoration: underline;
         text-decoration-thickness: 2px;

--- a/_sass/components/_banner.scss
+++ b/_sass/components/_banner.scss
@@ -1,0 +1,26 @@
+@import "settings/colors";
+
+/* Site-wide announcement banner.
+ *
+ * The banner content is loaded at page load from /assets/banner.html
+ * (see _layouts/default.html). If that file is empty, no banner is shown.
+ * See README.md ("Site-wide announcement banner") for details.
+ */
+.global-banner {
+    background-color: $orange;
+    color: $white;
+    // Increase contrast to make white text more readable
+    text-shadow: 0px 0px 4px $black;
+    text-align: center;
+    padding: 0.6em 1em;
+
+    p {
+        margin: 0;
+    }
+
+    a {
+        color: $white;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+    }
+}

--- a/_sass/components/_banner.scss
+++ b/_sass/components/_banner.scss
@@ -2,9 +2,9 @@
 
 /* Site-wide announcement banner.
  *
- * The banner content is loaded at page load from /assets/banner.html
- * (see _layouts/default.html). If that file is empty, no banner is shown.
- * See README.md ("Site-wide announcement banner") for details.
+ * The banner content comes from _includes/banner.html and is embedded at
+ * build time (see _layouts/default.html). If that file is empty, no banner
+ * is shown. See README.md ("Site-wide announcement banner") for details.
  */
 .global-banner {
     background-color: $orange;

--- a/assets/banner.html
+++ b/assets/banner.html
@@ -1,0 +1,6 @@
+  <p>
+    The Jupyter Foundation <a href="https://blog.jupyter.org/2026-jupyter-community-call-for-funding-proposals-f938928a1b8e">call for funding proposals</a> is now open.
+    <a href="https://jupyterfoundation.org/community-funding-proposals/submit-a-proposal/">
+      Submit a proposal
+    </a> for improving Jupyter.
+  </p>

--- a/assets/banner.html
+++ b/assets/banner.html
@@ -1,6 +1,7 @@
-  <p>
-    The Jupyter Foundation <a href="https://blog.jupyter.org/2026-jupyter-community-call-for-funding-proposals-f938928a1b8e">call for funding proposals</a> is now open.
-    <a href="https://jupyterfoundation.org/community-funding-proposals/submit-a-proposal/">
-      Submit a proposal
-    </a> for improving Jupyter.
-  </p>
+---
+# Publishes the shared announcement banner content at
+# https://jupyter.org/assets/banner.html for Jupyter documentation sites.
+# Do not edit the banner here: the content lives in _includes/banner.html.
+layout: null
+---
+{% capture banner %}{% include banner.html %}{% endcapture %}{{ banner | strip }}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -2,6 +2,7 @@
 # this ensures Jekyll reads the file to be transformed into CSS later
 # only Main files contain this front matter, not partials.
 ---
+@import "components/banner";
 @import "components/box";
 @import "components/copy";
 @import "components/headlines";


### PR DESCRIPTION
Adds a generic system for creating banners at the top of jupyer.org, and starts with a new banner for the Jupyter Foundation community proposal CFP.

Claude helped on this PR.
<img width="1765" height="622" alt="image" src="https://github.com/user-attachments/assets/fe7580b6-b1b2-4937-8bdf-99084969b50f" />

