### PR TITLE
Make it possible to dismiss announcement banners

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -91,6 +91,7 @@ jobs:
            --check-links-ignore "/" \
            --check-links-ignore "https://www.nyu.edu/" \
            --check-links-ignore ".github/images/netlify-preview.png" \
+           --check-links-ignore "_includes/banner.html" \
            --check-links-ignore ".*help.medium.com.*" \
            --check-links-ignore "https://twitter.com/.*" \
            --check-links-ignore "https://jupytercon.com" \

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Notes:
   own banner container and styling: jupyter.org styles it with the
   `.global-banner` component, and documentation sites style it with their
   theme's announcement banner.
+- On jupyter.org the banner can be dismissed. A dismissal remembers the most
+  recent banner text dismissed, so publishing a banner with different text shows
+  the banner again, even to visitors who dismissed a previous one.
 
 ### Subscribing a documentation site to the banner
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ Notes:
   own banner container and styling: jupyter.org styles it with the
   `.global-banner` component, and documentation sites style it with their
   theme's announcement banner.
-- On jupyter.org the banner can be dismissed. A dismissal remembers the most
-  recent banner text dismissed, so publishing a banner with different text shows
-  the banner again, even to visitors who dismissed a previous one.
+- On jupyter.org the banner can be dismissed. A dismissal remembers a normalized
+  text of the most recent dismissal, so publishing a banner with different text
+  shows the banner again. Since the text is normalized, though, just changing an
+  html link without changing the text will not show the banner again.
 
 ### Subscribing a documentation site to the banner
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,6 +93,43 @@ legal:
     </script>
   </head>
   <body>
+    <!-- Site-wide announcement banner. The content lives in
+         _includes/banner.html; leave that file empty to show no banner.
+         The same content feeds the announcement banner on Jupyter
+         documentation sites, via /assets/banner.html. See the "Site-wide
+         announcement banner" section in README.md. -->
+    {%- capture banner_content %}{% include banner.html %}{% endcapture %}
+    {%- assign banner_content = banner_content | strip %}
+    {%- if banner_content != "" %}
+    <div id="global-banner" class="global-banner">
+      <div class="global-banner-content">{{ banner_content }}</div>
+      <button type="button" class="global-banner-dismiss" aria-label="Dismiss this announcement">&times;</button>
+    </div>
+    <script>
+      // Hide the banner if this exact banner text was dismissed before.
+      // Dismissals are stored in localStorage as the banner text plus the
+      // dismissal date; changing the banner content shows it again.
+      (function () {
+        var banner = document.getElementById('global-banner');
+        var key = 'jupyter-banner-dismissal';
+        var text = banner.querySelector('.global-banner-content')
+          .textContent.replace(/\s+/g, ' ').trim();
+        try {
+          var dismissal = JSON.parse(localStorage.getItem(key));
+          if (dismissal && dismissal.text === text) {
+            banner.remove();
+            return;
+          }
+        } catch (e) {}
+        banner.querySelector('.global-banner-dismiss').addEventListener('click', function () {
+          try {
+            localStorage.setItem(key, JSON.stringify({ text: text, date: new Date().toISOString() }));
+          } catch (e) {}
+          banner.remove();
+        });
+      })();
+    </script>
+    {%- endif %}
     <nav class="navbar">
         <div class="navbar-header">
             <a class="navbar-brand" href="/">
@@ -151,16 +188,6 @@ legal:
             </ul>
         </div>
     </nav>
-    <!-- Site-wide announcement banner. The content lives in
-         _includes/banner.html; leave that file empty to show no banner.
-         The same content feeds the announcement banner on Jupyter
-         documentation sites, via /assets/banner.html. See the "Site-wide
-         announcement banner" section in README.md. -->
-    {%- capture banner_content %}{% include banner.html %}{% endcapture %}
-    {%- assign banner_content = banner_content | strip %}
-    {%- if banner_content != "" %}
-    <div id="global-banner" class="global-banner">{{ banner_content }}</div>
-    {%- endif %}
     <section>
       {{ content }}
     </section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -113,6 +113,7 @@ legal:
             banner.remove();
             return;
           }
+          localStorage.removeItem(key);
         } catch (e) {}
         banner.querySelector('.global-banner-dismiss').addEventListener('click', function () {
           try {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -117,7 +117,7 @@ legal:
         } catch (e) {}
         banner.querySelector('.global-banner-dismiss').addEventListener('click', function () {
           try {
-            localStorage.setItem(key, JSON.stringify({ text: text, date: new Date().toISOString() }));
+            localStorage.setItem(key, JSON.stringify({ text: text }));
           } catch (e) {}
           banner.remove();
         });

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,11 +93,6 @@ legal:
     </script>
   </head>
   <body>
-    {%- comment %} Site-wide announcement banner. The content lives in
-         _includes/banner.html; leave that file empty to show no banner.
-         The same content feeds the announcement banner on Jupyter
-         documentation sites, via /assets/banner.html. See the "Site-wide
-         announcement banner" section in README.md. {% endcomment %}
     {%- capture banner_content %}{% include banner.html %}{% endcapture %}
     {%- assign banner_content = banner_content | strip %}
     {%- if banner_content != "" %}
@@ -106,7 +101,7 @@ legal:
       <button type="button" class="global-banner-dismiss" aria-label="Dismiss this announcement">&times;</button>
     </div>
     <script>
-      // Hide the banner if this exact banner text was dismissed before.
+      // Hide the banner if the normalized banner text was dismissed before.
       (function () {
         var banner = document.getElementById('global-banner');
         var key = 'jupyter-banner-dismissal';

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,11 +93,11 @@ legal:
     </script>
   </head>
   <body>
-    <!-- Site-wide announcement banner. The content lives in
+    {%- comment %} Site-wide announcement banner. The content lives in
          _includes/banner.html; leave that file empty to show no banner.
          The same content feeds the announcement banner on Jupyter
          documentation sites, via /assets/banner.html. See the "Site-wide
-         announcement banner" section in README.md. -->
+         announcement banner" section in README.md. {% endcomment %}
     {%- capture banner_content %}{% include banner.html %}{% endcapture %}
     {%- assign banner_content = banner_content | strip %}
     {%- if banner_content != "" %}
@@ -107,8 +107,6 @@ legal:
     </div>
     <script>
       // Hide the banner if this exact banner text was dismissed before.
-      // Dismissals are stored in localStorage as the banner text plus the
-      // dismissal date; changing the banner content shows it again.
       (function () {
         var banner = document.getElementById('global-banner');
         var key = 'jupyter-banner-dismissal';

--- a/_sass/components/_banner.scss
+++ b/_sass/components/_banner.scss
@@ -1,16 +1,9 @@
 @import "settings/colors";
 
-/* Site-wide announcement banner.
- *
- * The banner content comes from _includes/banner.html and is embedded at
- * build time (see _layouts/default.html). If that file is empty, no banner
- * is shown. See README.md ("Site-wide announcement banner") for details.
- */
 .global-banner {
     position: relative;
     background-color: $orange;
     color: $white;
-    // Increase contrast to make white text more readable
     text-shadow: 0px 0px 4px $black;
     text-align: center;
     // Symmetric horizontal padding keeps the text centered while leaving

--- a/_sass/components/_banner.scss
+++ b/_sass/components/_banner.scss
@@ -7,12 +7,15 @@
  * is shown. See README.md ("Site-wide announcement banner") for details.
  */
 .global-banner {
+    position: relative;
     background-color: $orange;
     color: $white;
     // Increase contrast to make white text more readable
     text-shadow: 0px 0px 4px $black;
     text-align: center;
-    padding: 0.6em 1em;
+    // Symmetric horizontal padding keeps the text centered while leaving
+    // room for the absolutely-positioned dismiss button on the right.
+    padding: 0.6em 2.5em;
 
     p {
         margin: 0;
@@ -23,5 +26,20 @@
         color: $white;
         text-decoration: underline;
         text-decoration-thickness: 2px;
+    }
+
+    .global-banner-dismiss {
+        position: absolute;
+        top: 50%;
+        right: 0.5em;
+        transform: translateY(-50%);
+        background: none;
+        border: none;
+        padding: 0.2em 0.4em;
+        color: $white;
+        text-shadow: 0px 0px 4px $black;
+        font-size: 1.4em;
+        line-height: 1;
+        cursor: pointer;
     }
 }


### PR DESCRIPTION
We make it possible for users to dismiss announcement banners. A dismissal stores the last announcement text that was dismissed in local storage, so when the announcement is updated, the banner will automatically show again. The stored announcement is normalized to just the text with whitespace collapsed so that only substantial changes to the actual announcement text trigger the refresh.

We also move the banner to the very top, above the navbar. I think this is a more common place to put announcement banners.

<img width="1029" height="285" alt="image" src="https://github.com/user-attachments/assets/1c4c4fa5-6516-4565-ae42-3afc06cf16f9" />
