### PR TITLE
Cloudflare-based PR Preview

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,46 @@
+# Builds the Jekyll site for a pull request and saves the result as an
+# artifact. This workflow runs with no access to repository secrets, so it is
+# safe to run on pull requests from forks. The companion
+# preview-deploy.yml workflow picks up the artifact and publishes it to
+# Cloudflare Pages.
+
+name: Build PR preview
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Build site
+        run: bundle exec jekyll build
+
+      - name: Stage preview artifact
+        # The PR number rides along with the built site so that
+        # preview-deploy.yml (a workflow_run workflow, which has no direct
+        # pull_request context) knows which PR to comment on.
+        run: |
+          mkdir preview
+          mv _site preview/site
+          echo "${{ github.event.pull_request.number }}" > preview/pr-number.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: preview
+          path: preview
+          retention-days: 3

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -39,7 +39,7 @@ jobs:
           mv _site preview/site
           echo "${{ github.event.pull_request.number }}" > preview/pr-number.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: preview
           path: preview

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -31,9 +31,10 @@ jobs:
         run: bundle exec jekyll build
 
       - name: Stage preview artifact
-        # The PR number rides along with the built site so that
-        # preview-deploy.yml (a workflow_run workflow, which has no direct
-        # pull_request context) knows which PR to comment on.
+        # Record which PR this build came from. preview-deploy.yml (a
+        # workflow_run workflow, which has no direct pull_request context)
+        # treats this number as an untrusted claim and verifies it against
+        # the workflow run's head commit before using it.
         run: |
           mkdir preview
           mv _site preview/site

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -31,10 +31,7 @@ jobs:
         run: bundle exec jekyll build
 
       - name: Stage preview artifact
-        # Record which PR this build came from. preview-deploy.yml (a
-        # workflow_run workflow, which has no direct pull_request context)
-        # treats this number as an untrusted claim and verifies it against
-        # the workflow run's head commit before using it.
+        # Record which PR this build came from.
         run: |
           mkdir preview
           mv _site preview/site

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,82 @@
+# Deletes old Cloudflare Pages preview deployments.
+#
+# Cloudflare Pages never expires deployments on its own -- every PR preview
+# deployment stays published forever unless deleted (an open feature request:
+# https://community.cloudflare.com/t/deleting-old-deployments-feature-request/496069).
+# This workflow deletes preview deployments older than RETENTION_DAYS,
+# roughly matching the automatic deploy expiration Netlify used to provide
+# for this site's previews:
+# https://www.netlify.com/blog/automated-deploy-cleanup-and-new-deploy-retention-policies/
+#
+# Uses the same repository secrets as preview-deploy.yml (see the setup
+# instructions there). If the secrets are not configured (e.g. in a fork),
+# the job skips quietly rather than failing every week.
+
+name: Clean up old PR previews
+
+on:
+  schedule:
+    - cron: '17 4 * * 0' # weekly, Sunday 04:17 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  # Keep in sync with CLOUDFLARE_PROJECT_NAME in preview-deploy.yml.
+  CLOUDFLARE_PROJECT_NAME: jupyter-website-previews
+  RETENTION_DAYS: 90
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete preview deployments older than the retention period
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$CLOUDFLARE_API_TOKEN" ] || [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "Cloudflare secrets are not configured; nothing to clean up."
+            exit 0
+          fi
+
+          api="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PROJECT_NAME}/deployments"
+          auth=(-H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
+          cutoff="$(date -u -d "${RETENTION_DAYS} days ago" +%s)"
+
+          # Collect the ids of expired preview deployments across all pages
+          # first, then delete, so deletions don't shift the pagination.
+          expired=()
+          page=1
+          while :; do
+            resp="$(curl -sf "${auth[@]}" "${api}?page=${page}&per_page=25")"
+            batch="$(jq -r '.result[] | select(.environment == "preview")
+                             | [.id, .created_on] | @tsv' <<<"$resp")"
+            [ -n "$batch" ] || [ "$(jq '.result | length' <<<"$resp")" -gt 0 ] || break
+            while IFS=$'\t' read -r id created; do
+              [ -n "$id" ] || continue
+              if [ "$(date -d "$created" +%s)" -lt "$cutoff" ]; then
+                expired+=("$id")
+              fi
+            done <<<"$batch"
+            page=$((page + 1))
+          done
+
+          echo "Found ${#expired[@]} preview deployment(s) older than ${RETENTION_DAYS} days."
+
+          deleted=0
+          for id in "${expired[@]}"; do
+            # force=true also deletes deployments that a pr-N alias points
+            # at (the final deployment of a stale PR). Failures (e.g. a
+            # deployment Cloudflare refuses to delete) are warnings, not
+            # errors, so one stubborn deployment doesn't block the rest.
+            if curl -sf "${auth[@]}" -X DELETE "${api}/${id}?force=true" > /dev/null; then
+              deleted=$((deleted + 1))
+            else
+              echo "::warning::Could not delete deployment ${id}"
+            fi
+          done
+
+          echo "Deleted ${deleted} deployment(s)."

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,119 @@
+# Publishes a PR preview to Cloudflare Pages and comments the preview URL on
+# the pull request.
+#
+# This runs via workflow_run (not pull_request) so that the Cloudflare API
+# token is never exposed to code from forks: preview-build.yml builds the
+# site without secrets, and this workflow only handles the resulting static
+# files -- it never checks out or executes PR code.
+#
+# Cloudflare only hosts these previews (via a "Direct Upload" Pages project
+# with no custom domain attached). The production site at jupyter.org is
+# still built and served by GitHub Pages from the master branch.
+#
+# Required repository secrets:
+#   CLOUDFLARE_API_TOKEN  - API token with the "Cloudflare Pages: Edit"
+#                           permission
+#   CLOUDFLARE_ACCOUNT_ID - the Cloudflare account that owns the Pages
+#                           project
+# See the "Previewing a Pull Request" section of the README for setup
+# instructions.
+
+name: Deploy PR preview
+
+on:
+  workflow_run:
+    workflows: ["Build PR preview"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+env:
+  CLOUDFLARE_PROJECT_NAME: jupyter-website-previews
+
+concurrency:
+  group: preview-deploy-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download built site
+        uses: actions/download-artifact@v4
+        with:
+          name: preview
+          path: preview
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        # The artifact comes from an untrusted PR, so accept only digits.
+        run: |
+          number="$(tr -cd '0-9' < preview/pr-number.txt)"
+          if [ -z "$number" ]; then
+            echo "No PR number found in artifact" >&2
+            exit 1
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy preview/site
+            --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }}
+            --branch=pr-${{ steps.pr.outputs.number }}
+            --commit-hash=${{ github.event.workflow_run.head_sha }}
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const marker = '<!-- cloudflare-pages-preview -->';
+            const prNumber = Number(process.env.PR_NUMBER);
+            const body = [
+              marker,
+              '### <img src="https://raw.githubusercontent.com/jupyter/design/master/logos/Favicon/favicon.svg" width="16"> Preview for this PR',
+              '',
+              `:mag: **Preview**: ${process.env.PREVIEW_URL}`,
+              '',
+              `Built from commit ${process.env.HEAD_SHA}. The preview updates automatically on new commits.`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (c) => c.user.type === 'Bot' && c.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -68,7 +68,6 @@ on:
 
 permissions:
   actions: read
-  deployments: write
   pull-requests: write
 
 env:
@@ -161,37 +160,6 @@ jobs:
             --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }}
             --branch=pr-${{ steps.pr.outputs.number }}
             --commit-hash=${{ github.event.workflow_run.head_sha }}
-
-      - name: Record GitHub deployment
-        # Surfaces the preview in the PR's "Deployments" panel with a
-        # "View deployment" button, in addition to the comment below.
-        uses: actions/github-script@v9
-        env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          PREVIEW_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
-        with:
-          script: |
-            const run = context.payload.workflow_run;
-            const { data: deployment } = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: run.head_sha,
-              environment: 'preview',
-              transient_environment: true,
-              production_environment: false,
-              auto_merge: false,
-              required_contexts: [],
-              description: `Cloudflare Pages preview for PR #${process.env.PR_NUMBER}`,
-            });
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: deployment.id,
-              state: 'success',
-              environment_url: process.env.PREVIEW_URL,
-              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              description: 'Preview deployed to Cloudflare Pages',
-            });
 
       - name: Comment preview URL on PR
         uses: actions/github-script@v9

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download built site
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: preview
           path: preview
@@ -64,7 +64,7 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -75,7 +75,7 @@ jobs:
             --commit-hash=${{ github.event.workflow_run.head_sha }}
 
       - name: Comment preview URL on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           PREVIEW_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -8,8 +8,7 @@
 #
 # This two-workflow split follows GitHub's guidance for acting with
 # privileges on untrusted pull request code:
-# - "Preventing pwn requests" (GitHub Security Lab), which describes this
-#   exact pattern, including passing the PR number through the artifact:
+# - "Preventing pwn requests" (GitHub Security Lab), which describes the pattern
 #   https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 # - GitHub's secure-use reference, which requires workflow_run workflows to
 #   never check out untrusted code and to treat artifacts from other

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -6,17 +6,53 @@
 # site without secrets, and this workflow only handles the resulting static
 # files -- it never checks out or executes PR code.
 #
+# This two-workflow split follows GitHub's guidance for acting with
+# privileges on untrusted pull request code:
+# - "Preventing pwn requests" (GitHub Security Lab), which describes this
+#   exact pattern, including passing the PR number through the artifact:
+#   https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+# - GitHub's secure-use reference, which requires workflow_run workflows to
+#   never check out untrusted code and to treat artifacts from other
+#   workflows as untrusted input:
+#   https://docs.github.com/en/actions/reference/security/secure-use
+# - The workflow_run event reference, whose example demonstrates this same
+#   artifact handoff:
+#   https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run
+#
 # Cloudflare only hosts these previews (via a "Direct Upload" Pages project
 # with no custom domain attached). The production site at jupyter.org is
 # still built and served by GitHub Pages from the master branch.
 #
-# Required repository secrets:
-#   CLOUDFLARE_API_TOKEN  - API token with the "Cloudflare Pages: Edit"
-#                           permission
-#   CLOUDFLARE_ACCOUNT_ID - the Cloudflare account that owns the Pages
-#                           project
-# See the "Previewing a Pull Request" section of the README for setup
-# instructions.
+# We upload directly instead of using Cloudflare Pages' Git integration
+# because the Git integration does not build preview deployments for pull
+# requests from forks, which is how nearly all contributions to this repo
+# arrive:
+# https://developers.cloudflare.com/pages/configuration/git-integration/github-integration/
+# Feature request for fork PR support in the Git integration:
+# https://community.cloudflare.com/t/pages-preview-deployments-not-triggered-by-prs-from-forks/251385
+#
+# One-time setup (for maintainers):
+#
+# 1. In the Cloudflare account that will host the previews, create a
+#    "Direct Upload" Pages project named after CLOUDFLARE_PROJECT_NAME
+#    below:
+#
+#        npx wrangler pages project create jupyter-website-previews
+#
+#    (or in the Cloudflare dashboard: Workers & Pages > Create > Pages >
+#    Upload assets). Do not connect the project to a Git repository and do
+#    not attach a custom domain.
+#
+# 2. Create an API token (Cloudflare dashboard: My Profile > API Tokens)
+#    with the "Cloudflare Pages: Edit" account permission, scoped to that
+#    account.
+#
+# 3. Find the account ID on the Cloudflare dashboard's account overview
+#    page.
+#
+# 4. In this repository's Settings > Secrets and variables > Actions, add:
+#      CLOUDFLARE_API_TOKEN  - the API token from step 2
+#      CLOUDFLARE_ACCOUNT_ID - the account ID from step 3
 
 name: Deploy PR preview
 
@@ -51,16 +87,48 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Read PR number
+      - name: Read and verify PR number
         id: pr
-        # The artifact comes from an untrusted PR, so accept only digits.
-        run: |
-          number="$(tr -cd '0-9' < preview/pr-number.txt)"
-          if [ -z "$number" ]; then
-            echo "No PR number found in artifact" >&2
-            exit 1
-          fi
-          echo "number=$number" >> "$GITHUB_OUTPUT"
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // The artifact comes from an untrusted PR, so the recorded PR
+            // number is only a claim: a malicious PR could name some other
+            // PR to misdirect the preview. Verify the claim by checking
+            // that the named PR's head really is what this workflow run
+            // built. (The head commit alone can't identify the PR: the same
+            // commit can head several PRs at once.)
+            const fs = require('fs');
+            const claimed = Number(
+              (fs.readFileSync('preview/pr-number.txt', 'utf8').match(/\d+/) ?? [])[0]
+            );
+            if (!Number.isInteger(claimed)) {
+              core.setFailed('No PR number found in artifact');
+              return;
+            }
+            const run = context.payload.workflow_run;
+            let pr;
+            try {
+              ({ data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: claimed,
+              }));
+            } catch (e) {
+              core.setFailed(`Could not look up PR #${claimed}: ${e.message}`);
+              return;
+            }
+            if (
+              pr.head.sha !== run.head_sha ||
+              pr.head.repo.full_name !== run.head_repository.full_name ||
+              pr.head.ref !== run.head_branch
+            ) {
+              core.setFailed(
+                `PR #${claimed} does not match the head commit this workflow run built`
+              );
+              return;
+            }
+            core.setOutput('number', String(pr.number));
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -28,8 +28,8 @@
 # requests from forks, which is how nearly all contributions to this repo
 # arrive:
 # https://developers.cloudflare.com/pages/configuration/git-integration/github-integration/
-# Feature request for fork PR support in the Git integration:
-# https://community.cloudflare.com/t/pages-preview-deployments-not-triggered-by-prs-from-forks/251385
+# This is a known issue and Cloudflare says support will come in the future:
+# https://developers.cloudflare.com/pages/platform/known-issues/#builds-and-deployment
 #
 # One-time setup (for maintainers):
 #
@@ -54,6 +54,11 @@
 #      CLOUDFLARE_API_TOKEN  - the API token from step 2
 #      CLOUDFLARE_ACCOUNT_ID - the account ID from step 3
 
+# For precedence, see 
+# * https://github.com/marketplace/actions/refined-cloudflare-pages-action
+#   * used in https://github.com/json-schema-org/website/pull/785
+# * https://github.com/ddev/ddev.com/pull/430
+
 name: Deploy PR preview
 
 on:
@@ -63,6 +68,7 @@ on:
 
 permissions:
   actions: read
+  deployments: write
   pull-requests: write
 
 env:
@@ -79,6 +85,20 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: Check required secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          missing=0
+          for name in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing repository secret '$name'. See the one-time setup instructions at the top of this workflow file."
+              missing=1
+            fi
+          done
+          exit "$missing"
+
       - name: Download built site
         uses: actions/download-artifact@v8
         with:
@@ -141,6 +161,37 @@ jobs:
             --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }}
             --branch=pr-${{ steps.pr.outputs.number }}
             --commit-hash=${{ github.event.workflow_run.head_sha }}
+
+      - name: Record GitHub deployment
+        # Surfaces the preview in the PR's "Deployments" panel with a
+        # "View deployment" button, in addition to the comment below.
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: run.head_sha,
+              environment: 'preview',
+              transient_environment: true,
+              production_environment: false,
+              auto_merge: false,
+              required_contexts: [],
+              description: `Cloudflare Pages preview for PR #${process.env.PR_NUMBER}`,
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: 'success',
+              environment_url: process.env.PREVIEW_URL,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'Preview deployed to Cloudflare Pages',
+            });
 
       - name: Comment preview URL on PR
         uses: actions/github-script@v9

--- a/README.md
+++ b/README.md
@@ -7,16 +7,22 @@ This is the source to [Jupyter.org](https://jupyter.org/).
 
 There are two ways that this site is built:
 
-- **Pull Request previews** are built with [Netlify](https://netlify.com), a hosting service for static websites. See the section below for more information.
+- **Pull Request previews** are built by GitHub Actions and hosted on [Cloudflare Pages](https://pages.cloudflare.com/). See the section below for more information.
 - **Hosting for jupyter.org** is done via [GitHub Pages](https://pages.github.com/). GitHub will automatically use Jekyll to build the HTML for this site and host it at `jupyter.github.io`, which connects with [jupyter.org](https://jupyter.org).
 
 ## Preview changes in a Pull Request
 
-Netlify will automatically build a preview of the website in an open Pull Request. To see this, click on the **`Show all checks`** button just above the comment box in the Pull Request window. Then click on the **`details`** link on the **`deploy/netlify`** row to see a preview of the built site.
+When you open a Pull Request, the site is automatically built and deployed as
+a preview. A few minutes after each push, a bot comment appears on the Pull
+Request with a link to the preview site; the same comment is updated in place
+as you push new commits.
 
-Here's an image of this box on a GitHub PR page:
+The preview shows exactly what the site will look like with your changes,
+using the same Jekyll toolchain that builds the production site.
 
-![Netlify Preview Button](.github/images/netlify-preview.png)
+(Maintainers: the Cloudflare project and repository secrets that previews
+require are documented in
+[`.github/workflows/preview-deploy.yml`](.github/workflows/preview-deploy.yml).)
 
 ## Site-wide announcement banner
 


### PR DESCRIPTION
This experiments with a cloudflare-based PR preview mechanism as an attempt to resolve https://github.com/jupyter/jupyter.github.io/issues/768

Findings:

1. The cloudflare github integration only generates PR previews for branches on the main repo. In order to have pr previews from forks, we need to do something like the workflows in this PR.
2. Building pr previews from forks requires a two-step process that is a bit awkward in order to avoid leaking secrets.
    1. Build the site without any secrets. Upload the built site as an artifact
    2. Upload the artifact to cloudflare in a workflow that is triggered by successful completion of the workflow 1. This upload uses secret cloudflare tokens and is not directly tied to the PR. This means the preview is not just an action on the PR, and it is a bit awkward to update the PR (we have to find the PR number and edit a comment).
3. I experimented with generating a deploy to make the preview easier to find, but I think that pollutes the repo-wide deployments, which I don't think is worth it.
4. Cloudflare deployments apparently stick around forever (as opposed to Netlify previews that have I think a 90-day retention). I think that is a liability, so this workflow also includes a cron job to delete cloudflare deployments.

Overall, I think cloudflare previews are too complicated to pursue at this time. If their GitHub app supported generating pr previews from forks, and they introduced an automatic retention limit, I think it would be worth reconsidering.


Claude Fable 5 helped with this PR.