### PR TITLE
Write a "powered by netlify" link in the footer if we are build/serving on netlify

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -277,6 +277,11 @@ legal:
           <p>
               The Jupyter® and Jupyter Logo® trademarks are registered with the U.S. Patent & Trademark Office by <a href="https://lf-charities.org/">LF Charities</a>. © {{site.time | date: '%Y' }}
           </p>
+          {%- if site.netlify %}
+          <p>
+              This site is powered by <a href="https://www.netlify.com/" target="_blank" rel="noopener noreferrer">Netlify</a>.
+          </p>
+          {%- endif %}
         </div>
       </section>
     </footer>

--- a/_plugins/netlify.rb
+++ b/_plugins/netlify.rb
@@ -1,0 +1,4 @@
+# Expose whether this build is running on Netlify
+Jekyll::Hooks.register :site, :after_init do |site|
+  site.config["netlify"] = ENV["NETLIFY"] == "true"
+end


### PR DESCRIPTION
This is to satisfy the requirements of the Netlify open-source program (https://www.netlify.com/open-source/):

> Must feature a link to our service on your main page, or all internal pages.

Right now, we only serve pr previews on netlify.

<img width="923" height="329" alt="image" src="https://github.com/user-attachments/assets/06e42f26-8818-4ab9-8459-83137c3acc12" />

