### PR TITLE
Remove inactive social channels

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -103,7 +103,8 @@ jobs:
            --check-links-ignore "https://stackoverflow.com" \
            --check-links-ignore "https://opensource.org/licenses/BSD-3-Clause" \
            --check-links-ignore "https://www.cvedetails.com/vulnerability-list/vendor_id-15653/Jupyter.html" \
-           --check-links-ignore "https://blog.jupyter.org.*"
+           --check-links-ignore "https://blog.jupyter.org.*" \
+           --check-links-ignore "https://datasciencecornwall.blogspot.com/2019/06/python-data-science-for-kids-taster.html"
 
   lighthouse:
 

--- a/social.md
+++ b/social.md
@@ -27,9 +27,3 @@ List of channels actively maintained by JMS in alphabetical order:
 - Mastodon:  <https://hachyderm.io/@ProjectJupyter>
 - YouTube: <https://youtube.com/@projectjupyter>
 - Zulip: <https://jupyter.zulipchat.com>
-
-
-List of channels considered inactive but managed by the JMS:
-
-- Facebook: <https://facebook.com/projectjupyter>
-- Slack JupyterCon 2023: <https://jupyterconworkspace.slack.com>


### PR DESCRIPTION
As discussed in a JMS meeting, we are removing these inactive channels from the website

<img width="770" height="597" alt="image" src="https://github.com/user-attachments/assets/d00877c1-64e5-4c74-b11a-8b9d0d145637" />
