### PR TITLE
Jupyter Day 2026 banner

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,6 +1,3 @@
   <p>
-    The Jupyter Foundation <a href="https://blog.jupyter.org/2026-jupyter-community-call-for-funding-proposals-f938928a1b8e">call for funding proposals</a> is now open.
-    <a href="https://jupyterfoundation.org/community-funding-proposals/submit-a-proposal/">
-      Submit a proposal
-    </a> for improving Jupyter.
+    Join us for <a href="https://events.linuxfoundation.org/jupyter-day/">Jupyter Day 2026</a>, October 19, San Jose. <a href="https://events.linuxfoundation.org/jupyter-day/program/cfp/">Submit a talk</a> by September 13 or <a href="https://events.linuxfoundation.org/jupyter-day/sponsor/">sponsor the event</a>.
   </p>


### PR DESCRIPTION
Adds a banner advertising [Jupyter Day 2026](https://events.linuxfoundation.org/jupyter-day/)

<img width="1424" height="522" alt="image" src="https://github.com/user-attachments/assets/3b56e784-ef3c-4ac9-a05e-3904a7a15a19" />

[Live preview](https://deploy-preview-877--preview-jupyter-website.netlify.app)

(I'm trying to keep it short, but should we say `San Jose, CA` or `San Jose, USA` to make it clearer where it is?)