### PR TITLE
Revert "Change banner to advertise two upcoming events (#883)"

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,3 +1,3 @@
   <p>
-    Join us! <a href="https://events.linuxfoundation.org/open-source-summit-europe/features/co-located-events/#jupyter-mini-summit">Jupyter Mini Summit, Oct 6, Prague</a> · <a href="https://events.linuxfoundation.org/jupyter-day/">Jupyter Day, Oct 19, San Jose</a>
+    Join us for <a href="https://events.linuxfoundation.org/jupyter-day/">Jupyter Day 2026</a>, October 19, San Jose. <a href="https://events.linuxfoundation.org/jupyter-day/program/cfp/">Submit a talk</a> by September 13 or <a href="https://events.linuxfoundation.org/jupyter-day/sponsor/">sponsor the event</a>.
   </p>


### PR DESCRIPTION
This reverts commit 5950b9d46d984e8b8ba7517c22d08954379f5ce5.

This restores the banner to talk about the CFP for a day or two longer, until the CFP closes.
